### PR TITLE
Improved not-for-profit rules, fixed admin errors, added provisions for the execution of policy

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1,11 +1,9 @@
-
-
 ---
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 4
-01/10/2022
+Version 1.20: B.V Draft 5
+04/10/2022
 &nbsp;
 
 Adopted by the co-operative at a general meeting on: 
@@ -353,8 +351,7 @@ A member who for any reason holds less than the minimum number of shares is not 
 
 #### 24 Death of member (CNL ss93 & 102–106)
 
-The legal personal representative of a deceased member may apply to the board for a transfer of the  
-deceased member’s shares and interest (as defined in Division 8 of the law) in a form approved by the Board. 
+The legal personal representative of a deceased member may apply to the board for a transfer of the deceased member’s shares and interest (as defined in Division 8 of the law) in a form approved by the Board. 
 
 #### 25 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
 
@@ -492,7 +489,7 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 1. An item of business cannot be transacted at a general meeting unless a quorum of members is present when the meeting is considering the item.
 
-2. A member can be taken as being present "in person" if using a form of communication that allows reasonably contemporaneous and continuous communication between the other members taking part in the meeting.
+2. A member shall be taken as being present "in person" if using a form of communication that allows reasonably contemporaneous and continuous communication between the other members taking part in the meeting.
 
 3. Unless these rules state otherwise, 5 members (or 50% of total members entitled to vote rounded up to the nearest whole member, whatever is the lesser amount) present in person, each being entitled to exercise a vote, constitute a quorum.
 
@@ -828,9 +825,9 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 3. The chairperson may be removed, and a new chairperson elected, by:
 
-    a) ordinary resolution of the board, unless paragraph (b) applies; or
+    a) ordinary resolution of the board; or
 
-    b)  ordinary resolution at a general meeting, if these rules provide that the chairperson is elected at a general meeting of the co-operative.
+    b)  ordinary resolution at a general meeting.
 
 >**Note.** Subrule (3) does not affect the requirements of section 180 of the Law in respect of the removal of a director.
 
@@ -991,7 +988,7 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
 
 #### 67 Disposal of surplus funds during a financial year (CNL ss355–358)
 
-1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law and these Rules as determined by the board.
+1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law and these rules as determined by the board.
 
 2. The board may retain all or part of the surplus arising in any year from the business of the cooperative to be applied for the benefit of the cooperative.
 
@@ -1025,7 +1022,11 @@ operative, the rules may include additional financial statements or information.
 
 #### 71  Non-profit nature of the co-operative 
 
-1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative.
+1.  The assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative.
+
+2. This rule does not prevent the payment in good faith of market rate remuneration, or remuneration in the favour of the co-operative to any member for services rendered or expenses incurred by that member for the cooperative. 
+
+3. If another provision of the rules is inconsistent with this rule, this rule in that instance shall prevail.
 
 
 
@@ -1049,24 +1050,27 @@ operative, the rules may include additional financial statements or information.
 
 3. The cooperative may not approve any policy which, if that policy were a rule amendment, would not be permitted without prior approval of the Registrar under the Law.
 
->**Note.** Section 60 of the law prohibits certain Rule ammendments without prior approval from the Registrar, such as conversion of the cooperative or changes to the active membership provisions.
+>**Note.** Section 60 of the law prohibits certain rule ammendments without prior approval from the Registrar, such as conversion of the cooperative or changes to the active membership provisions.
 
 
 #### 74  Provisions for the execution of policies and first policy
 
-1. The first policy (The Policies Policy) of the co-operative must set out:
+1. The first policy (The Policies Policy) of the co-operative must include:
    
-   a) the general form of policies;
+   a) the general form of policies; and
    
-   b) how additional policies may be executed and ammended.
+   b) how additional policies may be executed and amended.
 
-2. The first policy of the co-operative may be executed by an ordinary resolution at a general meeting.
+2. Subrule 1 does not prevent the first policy from including any additional provisions as the co-operative sees fit. 
 
-3. Ammendments to the first policy cannot be executed by an ordinary resolution, unless permitted by a provision of the first policy.
+3. The first policy of the co-operative may be executed by an ordinary resolution at a general meeting.
 
-4. Ammendments to the first policy may be executed by way of special resolution.
+4. Amendments to the first policy cannot be executed by an ordinary resolution, unless permitted by a provision of the first policy.
+
+5. Amendments to the first policy may be executed by way of special resolution.
 
 
 #### 75  Availability of policies
 
 The policies must be made available to all prospective members of the co-operative, and a copy of any policy must be provided to members if requested alongside the rules when provided under rule 58 (3).
+

--- a/Rules.md
+++ b/Rules.md
@@ -2,8 +2,8 @@
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 5
-04/10/2022
+Version 1.20: B.V Draft 6
+05/10/2022
 &nbsp;
 
 Adopted by the co-operative at a general meeting on: 
@@ -1022,25 +1022,29 @@ operative, the rules may include additional financial statements or information.
 
 #### 71  Non-profit nature of the co-operative 
 
-1.  The assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative.
+1.  The assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members, employees, officers, or directors of the co-operative.
 
-2. This rule does not prevent the payment in good faith of market rate remuneration, or remuneration in the favour of the co-operative to any member for services rendered or expenses incurred by that member for the cooperative. 
+2. This rule does not stop the co-operative from doing the following things, provided they are done in good faith (fairly and honestly): 
+
+   a) paying a member for goods or services they have provided or expenses they have properly incurred at fair and reasonable rates or rates more favourable to the co-operative; or 
+
+   b) making a payment or providing a benefit to a member in carrying out the co-operative’s charitable purpose(s).
 
 3. If another provision of the rules is inconsistent with this rule, this rule in that instance shall prevail.
-
 
 
 ## Part 9 Policies of the co-operative
 
 #### 72  Effect of policies 
 
-1. The co-operative, as well as each member, director, officer and the secretary of the co-operative, must abide by the policies of the co-operative.
+1. The co-operative, as well as each member, director, officer and the secretary of the co-operative, must follow the policies of the co-operative.
 
-2. The policies of the co-operative may conditionally or unconditionally limit the powers of, or restrict or dictate the decisions or resolutions which may be made by, the co-operative, as well as each member, director, officer or the secretary of the co-operative.
+2. The policies of the co-operative may (conditionally or unconditionally) limit the powers of or restrict or dictate the decisions or resolutions of the co-operative, as well as each member, director, officer or the secretary of the co-operative.
 
 3. The policies may prescribe specific situations where members shall be or suspended or expelled. 
 
 4. An ordinary resolution may overturn or repeal a suspension or expellation of a member, but only if a policy was the sole mechanism of suspension or expellation. 
+
 
 #### 73  Limitations of policies
 
@@ -1073,4 +1077,3 @@ operative, the rules may include additional financial statements or information.
 #### 75  Availability of policies
 
 The policies must be made available to all prospective members of the co-operative, and a copy of any policy must be provided to members if requested alongside the rules when provided under rule 58 (3).
-

--- a/Rules.md
+++ b/Rules.md
@@ -42,7 +42,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 
    **member** means a member of the co-operative.
    
-   **member director and non-member director**—see section 174 of the Law and rule 45.
+   **member director and non-member director**â€”see section 174 of the Law and rule 45.
    
    **standard postal times** means the times when properly addressed and prepaid letters would be delivered in the ordinary course of post.
 
@@ -57,7 +57,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 2. Except so far as the contrary intention appears in these rules, words and expressions used in these rules have the same meanings as they have, from time to time, in the Law or relevant provisions of the Law.
 
 
-#### 3 Name and primary activity of the co-operative (CNL ss220–222 & 224)
+#### 3 Name and primary activity of the co-operative (CNL ss220â€“222 & 224)
 
 1.  The name of the co-operative is The Electric Boogaloo Co-operative Ltd.
 
@@ -72,7 +72,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 ### Division 1 Membership generally
 
 
-#### 4 Active membership provisions (CNL ss112(2), 144, 148 & 156–166)
+#### 4 Active membership provisions (CNL ss112(2), 144, 148 & 156â€“166)
 
 1. Primary activity 
 
@@ -107,7 +107,7 @@ A person qualifies for membership of the co-operative if the person is able to u
   
 2. Every application must be considered by the board.
 
-3. If the board approves the application, the applicant’s name and any other information required under the Law must be entered in the register of members within 28 days of the board’s approval.
+3. If the board approves the application, the applicantâ€™s name and any other information required under the Law must be entered in the register of members within 28 days of the boardâ€™s approval.
 
 4. The applicant must be notified in writing of the entry in the register and the applicant is then entitled to the privileges attaching to membership.
 
@@ -129,7 +129,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 1. A member may be expelled from the co-operative by special resolution to the effect:
 
-    a) that the member has seriously or repetitively failed to discharge the member’s obligations to the co-operative under these rules or a contract entered into with the co-operative under section 125 of the Law; or
+    a) that the member has seriously or repetitively failed to discharge the memberâ€™s obligations to the co-operative under these rules or a contract entered into with the co-operative under section 125 of the Law; or
     
     b) that the member has acted in a way that has:
     
@@ -145,7 +145,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
    a)  at the meeting, the member must be afforded a full opportunity to be heard and is entitled to call witnesses and cross-examine witnesses called against the member;
 
-   b) if the member fails to attend at the time and place mentioned, without reasonable excuse, the member’s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
+   b) if the member fails to attend at the time and place mentioned, without reasonable excuse, the memberâ€™s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
     
    c) once the alleged conduct is considered, the co-operative may decide to expel the member concerned;
     
@@ -160,7 +160,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 #### 10 Resignation of members (CNL s117)
 
-A member may resign from a co-operative by giving two weeks’ notice in writing in the form approved by the board.
+A member may resign from a co-operative by giving two weeksâ€™ notice in writing in the form approved by the board.
 
 
 #### 11 Monetary consequences of expulsion or resignation (CNL s128)
@@ -173,7 +173,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing i
 
 3. The shares of an expelled or resigning member must be cancelled as at the day of expulsion or resignation, and the cancellation must be noted in the register of shares.
 
-4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former member’s shares at the time of expulsion or resignation (less any amount owing by the former member to the co- operative).
+4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former memberâ€™s shares at the time of expulsion or resignation (less any amount owing by the former member to the co- operative).
 
 5. If a deficiency exists, an appropriate proportion of the loss, deficiency or significant change may be deducted from the amount of capital paid up on the shares of the expelled or resigning member. This is done having regard to the number of shares held by the expelled or resigning member immediately before expulsion or resignation in relation to the number of shares in the co-operative.
 
@@ -259,7 +259,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing i
 >**Note.** Section 130 of the Law applies if mediation does not resolve the dispute.
 
 
-### Division 3 Members’ liability
+### Division 3 Membersâ€™ liability
 
 #### 14 Fines payable by members (CNL ss56 & 126)
 
@@ -283,7 +283,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing i
 
 ### Division 4 Shares
 
-#### 16 Capital and shares (CNL ss76–82)
+#### 16 Capital and shares (CNL ss76â€“82)
 
 1. The capital of the co-operative must be raised by the issue of shares with a nominal value  of $1 each.
 
@@ -305,7 +305,7 @@ No calls on shares will be made.
 >**Note.** 100% of the value of shares must be paid in full at time of application
 
 
-#### 18 Repurchase of members’ shares (CNL ss99, 107, 109 & 118)
+#### 18 Repurchase of membersâ€™ shares (CNL ss99, 107, 109 & 118)
 
 A share may not be repurchased, except when required under these rules or the Law.
 
@@ -323,7 +323,7 @@ A member who for any reason holds less than the minimum number of shares is not 
 
 ### Division 5 Member cancellations
 
-#### 21 Forfeiture and cancellations—inactive members (CNL ss156–163)
+#### 21 Forfeiture and cancellationsâ€”inactive members (CNL ss156â€“163)
 
 1. The board must declare the membership of a member cancelled if:
 
@@ -339,7 +339,7 @@ A member who for any reason holds less than the minimum number of shares is not 
 2. Forfeited shares must be cancelled.
 
 
-#### 23 Forfeited shares—liability of members
+#### 23 Forfeited sharesâ€”liability of members
 
 1. A person whose shares have been forfeited under these rules or the Law stops being a member. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by them to the co-operative for the shares.
 
@@ -351,20 +351,20 @@ A member who for any reason holds less than the minimum number of shares is not 
 
 ### Division 6 Deceased or incapacitated members
 
-#### 24 Death of member (CNL ss93 & 102–106)
+#### 24 Death of member (CNL ss93 & 102â€“106)
 
 The legal personal representative of a deceased member may apply to the board for a transfer of the  
-deceased member’s shares and interest (as defined in Division 8 of the law) in a form approved by the Board. 
+deceased memberâ€™s shares and interest (as defined in Division 8 of the law) in a form approved by the Board. 
 
 #### 25 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
 
-1. A person’s membership may continue upon bankruptcy for so long as that member continues to meet all regular membership requirements. 
+1. A personâ€™s membership may continue upon bankruptcy for so long as that member continues to meet all regular membership requirements. 
 
-2. A person appointed under a law of a State or Territory to administer the estate of a member who, through mental or physical infirmity, is incapable of managing his or her affairs, may be registered as the holder of the member’s shares and the rights and liabilities of membership vest in that person during the period of the appointment.
+2. A person appointed under a law of a State or Territory to administer the estate of a member who, through mental or physical infirmity, is incapable of managing his or her affairs, may be registered as the holder of the memberâ€™s shares and the rights and liabilities of membership vest in that person during the period of the appointment.
 
 3. The liabilities attaching to the shares of a person under mental incapacity continue in accordance with section 96 of the Law.
 
-4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the member’s physical or mental infirmity is temporary.
+4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the memberâ€™s physical or mental infirmity is temporary.
 
 
 #### 26 Entitlements and liabilities of person registered as trustee, administrator etc.
@@ -397,7 +397,7 @@ deceased member’s shares and interest (as defined in Division 8 of the law) in a
     
 5. Debentures must be transferred in a form approved by the board
 
-#### 28 Issue of CCUs (CNL ss345–354)
+#### 28 Issue of CCUs (CNL ss345â€“354)
 
 The board must not issue CCUs.
 
@@ -413,7 +413,7 @@ The board must not issue CCUs.
 An annual general meeting must be held each year, at a place and on a date and a time decided by the board, within 5 months after the close of the financial year of the co-operative or within the further time allowed by the Registrar.
 
 
-#### 31 Members’ power to requisition a general meeting (CNL s257)
+#### 31 Membersâ€™ power to requisition a general meeting (CNL s257)
 
 1. The board may, whenever it considers appropriate, call a special general meeting of the co-operative.
 
@@ -424,11 +424,11 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 #### 32 Notice of general meetings (CNL ss239, 254 & 611)
 
-1. At least 14 days’ notice of a general meeting (not including the day on which the notice is served or taken to be served, but including the day for which notice is given) must be given.
+1. At least 14 daysâ€™ notice of a general meeting (not including the day on which the notice is served or taken to be served, but including the day for which notice is given) must be given.
 
-> **Note 1.** If there is to be a special resolution proposed at the meeting, there is a requirement for at least 21 days’ notice of the special resolution.
+> **Note 1.** If there is to be a special resolution proposed at the meeting, there is a requirement for at least 21 daysâ€™ notice of the special resolution.
 
-> **Note 2.** If there is a resolution proposed for the removal of a director, section 180 of the Law requires special notice of the resolution and 21 days’ notice of the meeting.
+> **Note 2.** If there is a resolution proposed for the removal of a director, section 180 of the Law requires special notice of the resolution and 21 daysâ€™ notice of the meeting.
 
 2. Notice must be given to each member of the co-operative and any other persons who are, under these rules or the Law, entitled to receive notices from the co-operative.
 
@@ -436,7 +436,7 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 3. The notice must state the place, day and hour of the meeting and include ordinary business as specified in rule 33 and, for special business, the general nature of any special business.
 
-4. The notice must also include any business members have notified their intention to move at the meeting under subrule (6) (but only if the members’ notification has been made under these rules and within time).
+4. The notice must also include any business members have notified their intention to move at the meeting under subrule (6) (but only if the membersâ€™ notification has been made under these rules and within time).
 
 5. The notice must be served in the manner provided in the Law or rule 62.
 
@@ -473,11 +473,11 @@ An annual general meeting must be held each year, at a place and on a date and a
     
     &nbsp;&nbsp; ii) a report on the state of affairs of the co-operative;
     
-    &nbsp;&nbsp; iii) a directors’ solvency resolution as to whether or not, in their opinion, there are reasonable grounds to believe that the co-operative will be able to pay its debts as and when they become due and payable; and
+    &nbsp;&nbsp; iii) a directorsâ€™ solvency resolution as to whether or not, in their opinion, there are reasonable grounds to believe that the co-operative will be able to pay its debts as and when they become due and payable; and
     
     c) to approve any payments of fees to directors.
 
->**Note 1.** A small co-operative must prepare and send to members minimum financial statements that are specified in regulation 3.10 of the National Regulations (these are referred as “basic minimum financial statements”). A co-operative may require more than the basic minimum financial statements to be provided to members and, if so, the additional financial statements should be specified in this rule.
+>**Note 1.** A small co-operative must prepare and send to members minimum financial statements that are specified in regulation 3.10 of the National Regulations (these are referred as â€œbasic minimum financial statementsâ€). A co-operative may require more than the basic minimum financial statements to be provided to members and, if so, the additional financial statements should be specified in this rule.
 
 >**Note 2.** If the small co-operative has consolidated gross assets of less than $250,000 and consolidated revenue of less than $750,000, the financial statement for the small co-operative need not include a cash flow statement (as provided in regulation 3.10 of the National Regulations).
 
@@ -631,7 +631,7 @@ Voting by proxy is not permitted at a general meeting.
 4. If the board decides to conduct a secret postal ballot, it must ensure that the method used to conduct the ballot will ensure that votes can be counted without identifying the way each member has voted.
 
 
-#### 43 Special resolutions (CNL ss238–241)
+#### 43 Special resolutions (CNL ss238â€“241)
 
 1. A special resolution is a resolution that is passed:
 
@@ -674,7 +674,7 @@ Voting by proxy is not permitted at a general meeting.
     
     b) not an active member but who possesses special skills in management or other technical areas of benefit to the co-operative as specified by the board from time to time.
 
-2. A person qualified to be a director under subrule (1)(a) is known as a “member director”. A person qualified under subrule (1)(b) is known as a “non-member director”.
+2. A person qualified to be a director under subrule (1)(a) is known as a â€œmember directorâ€. A person qualified under subrule (1)(b) is known as a â€œnon-member directorâ€.
 
 3. The board of directors must have a majority of member directors.
 
@@ -691,7 +691,7 @@ Voting by proxy is not permitted at a general meeting.
 
 5. The chief executive officer cannot be required to be an active member of the co-operative.
 
-6. In the event of any conflict between the terms of the appointment of a person as the chief executive officer and that person’s obligations or privileges under the Law, the terms of the Law prevail over the terms of appointment.
+6. In the event of any conflict between the terms of the appointment of a person as the chief executive officer and that personâ€™s obligations or privileges under the Law, the terms of the Law prevail over the terms of appointment.
 
 
 #### 47 First directors and election of directors (CNL ss173 & 179)
@@ -702,7 +702,7 @@ Voting by proxy is not permitted at a general meeting.
 
 2. The term of office of the first directors is to be not more than 3 years ending on the day of the third annual general meeting after the formation meeting.
 
->**Note.** The rules may require that directors’ terms are of different length to enable rotational retirement.
+>**Note.** The rules may require that directorsâ€™ terms are of different length to enable rotational retirement.
 
 3. The term of office of directors elected thereafter, is to commence from the annual general meeting at which they are elected and ends on the day of the third annual general meeting thereafter.
 
@@ -735,11 +735,11 @@ Voting by proxy is not permitted at a general meeting.
     
     e) The secretary, or an officer nominated by the board, must give details of each person who has been nominated to members with the notice of the annual general meeting. Details to be provided to members must include:
     
-    &nbsp;&nbsp; i) the nominee’s name; and
+    &nbsp;&nbsp; i) the nomineeâ€™s name; and
     
-    &nbsp;&nbsp; ii) the nominee’s qualifications and experience; and
+    &nbsp;&nbsp; ii) the nomineeâ€™s qualifications and experience; and
     
-    &nbsp;&nbsp; iii) the nominee’s length of any previous service as a director of the co-operative or with any other co-operative.
+    &nbsp;&nbsp; iii) the nomineeâ€™s length of any previous service as a director of the co-operative or with any other co-operative.
 
 6. If the number of nominees equals the number of vacancies, the nominees must be declared elected at the annual general meeting.
 
@@ -762,7 +762,7 @@ Voting by proxy is not permitted at a general meeting.
 
 #### 48 Removal from office of director (CNL s180)
 
-The co-operative may by resolution under section 180 of the Law, with special notice as required by that section, remove a director before the end of the director’s period of office, and may by a simple majority appoint another person in place of the removed director. The person appointed must retire when the removed director would otherwise have retired.
+The co-operative may by resolution under section 180 of the Law, with special notice as required by that section, remove a director before the end of the directorâ€™s period of office, and may by a simple majority appoint another person in place of the removed director. The person appointed must retire when the removed director would otherwise have retired.
 
 
 #### 49 Vacation of office of director (CNL s179)
@@ -778,9 +778,9 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
 3. A person is not qualified to be appointed as an alternate director for:
 
-    a) a member director—unless the person is qualified for appointment as a member director; or
+    a) a member directorâ€”unless the person is qualified for appointment as a member director; or
 
-    b) a non-member director—unless the person is qualified for appointment as a non-member director.
+    b) a non-member directorâ€”unless the person is qualified for appointment as a non-member director.
     
 4. An alternate director holds office until the next annual general meeting or until the next general meeting held to elect directors to fill any vacancies (whichever is earlier).
 
@@ -793,7 +793,7 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
 #### 51 Remuneration of directors (CNL s203)
 
-Directors’ remuneration must comply with the provisions of the Law.
+Directorsâ€™ remuneration must comply with the provisions of the Law.
 
 > **Note 1.** Remuneration for directors is strictly controlled under the Law and requires the approval of the co- operative in general meeting. However, it is possible for a co-operative to specify in its rules that a director will receive particular remuneration if this is appropriate. It may still be necessary to obtain ratification or approval at a general meeting even in respect of specified remuneration under the rules.
 
@@ -849,7 +849,7 @@ Directors’ remuneration must comply with the provisions of the Law.
 
     e)   a committee of directors and other persons;
 
-    the exercise of the board’s powers (other than this power of delegation) specified in the resolution. The co- operative or the board may by resolution revoke all or part of the delegation.
+    the exercise of the boardâ€™s powers (other than this power of delegation) specified in the resolution. The co- operative or the board may by resolution revoke all or part of the delegation.
 
 2. A power delegated under this rule may, while the delegation remains unrevoked, be exercised from time to time in accordance with the delegation.
 
@@ -893,9 +893,9 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 ## Part 5 Rules
 
-#### 58 Amendments and copies of rules (CNL ss57 & 60–63)
+#### 58 Amendments and copies of rules (CNL ss57 & 60â€“63)
 
-1. Any amendment of the rules must be approved by special resolution. However, if model rules are adopted in the manner specified under section 65(a) of the Law, any amendments to the model rules as notified by the Registrar are included in the co-operative’s rules without the need for a special resolution.
+1. Any amendment of the rules must be approved by special resolution. However, if model rules are adopted in the manner specified under section 65(a) of the Law, any amendments to the model rules as notified by the Registrar are included in the co-operativeâ€™s rules without the need for a special resolution.
 
 > **Note.** Section 60 of the Law permits the Registrar to specify classes of rules that must not be changed without first obtaining the approval of the Registrar. A co-operative should check whether any prior approval is required before the change is put to a special resolution vote.
 
@@ -913,7 +913,7 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 1. This rule applies if the co-operative chooses to authenticate a document under the common seal of the co-operative.
 
-2. The co-operative’s name and registration number must appear on its common seal and any official seal. The common seal must be kept at the registered office in the custody that the board directs.
+2. The co-operativeâ€™s name and registration number must appear on its common seal and any official seal. The common seal must be kept at the registered office in the custody that the board directs.
 
 3. The co-operative may have one or more official seals for use outside the State or Territory in place of its common seal. Each of the additional seals must be a facsimile of the common seal with the addition on its face of the name of the place where it is to be used.
 
@@ -989,26 +989,27 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
 2. An auditor or reviewer appointed under this rule holds office until the financial report prepared as a result of the direction has been audited or reviewed and sent to members.
 
 
-#### 67 Disposal of surplus funds during a financial year (CNL ss355–358)
+#### 67 Disposal of surplus funds during a financial year (CNL ss355â€“358)
 
-1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law as determined by the board.
+1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law and these Rules as determined by the board.
 
-2. A part of the surplus, but no less than 30%, arising in a year from the business of the co-operative shall be retained to later be applied for the benefit of the co-operative.
+2. The board may retain all or part of the surplus arising in any year from the business of the cooperative to be applied for the benefit of the cooperative.
 
-3. A part of the surplus, but no more than 70%, arising in a year from the business of the co-operative may be applied for any charitable purposes.
+3. A part of the surplus, but no more than 99%, arising in a year from the business of the co-operative may be applied for any charitable purposes.
 
 
 #### 68 Provision for loss
 
-The board must make appropriate provision for losses in the co-operative’s accounts and when reporting to members is to indicate whether the loss is expected to continue and whether there is any real prejudice to the co-operative’s solvency.
+The board must make appropriate provision for losses in the co-operativeâ€™s accounts and when reporting to members is to indicate whether the loss is expected to continue and whether there is any real prejudice to the co-operativeâ€™s solvency.
 
 
 #### 69 Financial reports to members (CNL Part 3.3)
 
 The co-operative must prepare financial reports and statements in accordance with the Law, the National Regulations and these rules.
 
->**Note.** The financial reports or statements required by the Law to be given to members vary according to the size of a co-operative in a given year. Large co-operatives are required to prepare and lodge with the Registrar full audited financial reports as set out in Part 3.3 of the Law. Small co-operatives are not required to lodge financial reports with the Registrar but are required to lodge an annual return under section 293 of the Law and provide
-
+>**Note.** The financial reports or statements required by the Law to be given to members vary according to the size of a co-operative in a given year. Large co-operatives are required to prepare and lodge with the Registrar full audited financial reports as set out in Part 3.3 of the Law. Small co-operatives are not required to lodge financial reports with the Registrar but are required to lodge an annual return under section 293 of the Law and provide members with basic minimum financial statements set out in the National Regulations. If the basic
+minimum reports prescribed in the National Regulations are not considered sufficient for a particular co-
+operative, the rules may include additional financial statements or information.
 
 
 ## Part 8 Winding up and non-profit nature of the co-operative 
@@ -1017,14 +1018,14 @@ The co-operative must prepare financial reports and statements in accordance wit
     
 1.  The winding up of the co-operative must be in accordance with Part 4.5 of the Law.
     
-2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operative’s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, which is charitable at law and which has rules prohibiting the distribution of its assets and income to its members.
+2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operativeâ€™s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, which is charitable at law and which has rules prohibiting the distribution of its assets and income to its members.
 
 3.  If on the winding up or dissolution there is a deficiency, members are liable to contribute towards the deficiency to the extent of any amount unpaid on the shares held by the member and any charges payable by the member to the co-operative as required by these rules.
 
 
 #### 71  Non-profit nature of the co-operative 
 
-1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative
+1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative.
 
 
 

--- a/Rules.md
+++ b/Rules.md
@@ -1,24 +1,29 @@
+
 ---
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.12 – 16/12/2021
+Version 1.20: B.V Draft 1
+20/09/2022
 &nbsp;
 
-Approved by Consumer and Business Services on: 30/05/2022
+Adopted by the co-operative at a general meeting on: 
 
-Adopted by the co-operative at its formation meeting on: 05/05/2022
+Registered with Consumer and Business Services on: 
 &nbsp;
+
+
 
 ## Part 1 Preliminary
-
 
 
 #### 1 Application of these rules
 
 These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 
+
 #### 2 Definitions
+
 1. In these rules:
 
    **ballot paper** means a ballot paper in paper or electronic form.
@@ -50,9 +55,13 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 
 2. Except so far as the contrary intention appears in these rules, words and expressions used in these rules have the same meanings as they have, from time to time, in the Law or relevant provisions of the Law.
 
-#### 3 Name of the co-operative (CNL ss220–222 & 224)
 
-   The name of the co-operative is The Electric Boogaloo Co-operative Ltd.
+#### 3 Name and primary activity of the co-operative (CNL ss220–222 & 224)
+
+1.  The name of the co-operative is The Electric Boogaloo Co-operative Ltd.
+
+2. The primary activity of the co-operative is the advancement of culture through the fostering, development, and exhibition of the arts, primarily through the management of venues and events.
+
 
 
 
@@ -62,25 +71,23 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 ### Division 1 Membership generally
 
 
-
 #### 4 Active membership provisions (CNL ss112(2), 144, 148 & 156–166)
+
 1. Primary activity 
 
-    For the purposes of Part 2.6 of the Law, the primary activities of the co-operative are the advancement of culture through the fostering, development, and exhibition of the arts, primarily through the management of venues and events.
+    For the purposes of Part 2.6 of the Law, the primary activities of the co-operative are as set out in rule 3 (2).
 
 2. Active membership requirements 
 
    To establish and maintain active membership of the co-operative a member must make contributions to the operation of the co-operative either financially or through non-cash benefits (e.g. labour), to the value of at least $50 every month.
 
-3. The assets and income of the co-operative shall be applied solely to further its objects and no portion shall be distributed directly or indirectly to the members of the organisation except as reasonable remuneration for services rendered or expenses incurred on behalf of the co-operative.
-
-5. Reasonable remuneration shall be divided from a remuneration pool between members proportionally to the hours contributed, limited to the minimum hourly pay under the Modern Award as relevant to the services rendered in each time period.
-
 > **Note.** Failure to maintain active membership may lead to cancellation of membership (see rule 21).
+
 
 #### 5 Qualifications for membership (CNL s112)
 
 A person qualifies for membership of the co-operative if the person is able to use or contribute to the services of the co-operative.
+
 
 #### 6 Entry fees and regular subscriptions (CNL s124)
 
@@ -88,7 +95,9 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 3. The regular subscription (also known as a periodic membership fee) is $0
 
+
 #### 7 Membership applications
+
 1. Applications for membership must be lodged at the registered office in the application form approved by the board, and should be accompanied by:
 
     a) payment of any applicable entry fee or subscription set under rule 6; and
@@ -105,6 +114,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 6. The board need not assign reasons for the refusal. On refusal any amounts accompanying the application for membership must be refunded within 28 days without interest.
 
+
 #### 8 Cessation of membership (CNL s117)
 
 1. A person ceases to be a member in any of the following circumstances:
@@ -116,6 +126,7 @@ A person qualifies for membership of the co-operative if the person is able to u
     c) if the member’s total shareholding is purchased by the co-operative under the Law or these rules;
     
     d) if the member’s total shareholding is sold by the co-operative under any power in the Law or these rules and the purchaser is registered as shareholder in the member’s place.
+    
     
 #### 9 Expulsion of members (CNL s117)
 
@@ -135,27 +146,30 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 3. At the general meeting when the special resolution for expulsion is proposed the following procedures apply:
 
-4. at the meeting, the member must be afforded a full opportunity to be heard and is entitled to call witnesses and cross-examine witnesses called against the member;
+   a)  at the meeting, the member must be afforded a full opportunity to be heard and is entitled to call witnesses and cross-examine witnesses called against the member;
 
-    a) if the member fails to attend at the time and place mentioned, without reasonable excuse, the member’s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
+   b) if the member fails to attend at the time and place mentioned, without reasonable excuse, the member’s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
     
-    b) once the alleged conduct is considered, the co-operative may decide to expel the member concerned;
+   c) once the alleged conduct is considered, the co-operative may decide to expel the member concerned;
     
-    c) the co-operative must not make a decision on the alleged conduct or on expulsion, except by vote by secret ballot of the members present, in person or represented by proxy or by attorney, and entitled to vote;
+   d) the co-operative must not make a decision on the alleged conduct or on expulsion, except by vote by secret ballot of the members present, in person or represented by proxy or by attorney, and entitled to vote;
     
-    d) a motion for the decision is not taken to be passed unless two-thirds of the members present, in person or represented by proxy or by attorney, vote in favour of the motion.
+   e) a motion for the decision is not taken to be passed unless two-thirds of the members present, in person or represented by proxy or by attorney, vote in favour of the motion.
     
-5. Expulsion of one joint member means expulsion of all members holding membership jointly with the expelled member.
+4. Expulsion of one joint member means expulsion of all members holding membership jointly with the expelled member.
 
-6. An expelled member must not be re-admitted as a member unless the re-admission is approved by special resolution.
+5. An expelled member must not be re-admitted as a member unless the re-admission is approved by special resolution.
 
-8. A member re-admitted must not have restored to him or her any shares that were cancelled on his or her expulsion.
+6. A member re-admitted must not have restored to him or her any shares that were cancelled on his or her expulsion.
+
 
 #### 10 Resignation of members (CNL s117)
 
 A member may resign from a co-operative by giving two weeks’ notice in writing in the form approved by the board.
 
+
 #### 11 Monetary consequences of expulsion or resignation (CNL s128)
+
 1. In this rule:
 
     **deficiency** means the amount of accumulated loss, deficiency or significant change disclosed in the last balance sheet of the co-operative, or later reported before expulsion.
@@ -174,7 +188,9 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
    
     b) may be applied at the time decided by the board, but within one year from the date of expulsion or resignation, in the manner set out in section 128 of the Law, if there is agreement by the board and former member or if the board considers that repayment would adversely affect the financial position of the co-operative.
 
+
 #### 12 Suspension of members
+
 1. The co-operative may suspend a member for not more than one year, who does any of the following:
 
     a) contravenes any of these rules;
@@ -192,6 +208,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
     b) is not entitled to a refund, rebate, relief or credit for membership fees paid, or payable, to the co- operative; and
     
     c) remains liable for any fine that may be imposed.
+
 
 
 ### Division 2 Dispute resolution
@@ -259,6 +276,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
     
     b) the member has been given a reasonable opportunity to appear before the board in person (with or without witnesses), or to send to the board a written statement, to show cause why the fine should not be imposed.
 
+
 #### 15 Liability of members to co-operatives (CNL ss117(2) & 121)
 
 1. A member is liable to the co-operative for the amount, if any, unpaid on the shares held by the member, together with any charges, including entry fees and regular subscriptions, payable by the member to the co-operative under these rules.
@@ -267,8 +285,6 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
 
 ### Division 4 Shares
-
-
 
 #### 16 Capital and shares (CNL ss76–82)
 
@@ -283,6 +299,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 5. A share in the co-operative does not carry a vote.
 
 6. The right to vote in the co-operative is attached to membership and governed by section 228 of the Law.
+
 
 #### 17 Calls on shares
 
@@ -305,6 +322,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 9. The board may accept from a member all or part of the money uncalled and unpaid on shares held by the member.
  
 10. The board may authorise payment by the co-operative of interest on all or part of an amount accepted under subrule (9) until the amount becomes payable, at a rate agreed between the board and the member paying the amount, of not more than 8% per annum or another rate fixed by the co-operative by special resolution.
+
 
 #### 18 Repurchase of members’ shares (CNL ss99, 107, 109 & 118)
 
@@ -329,14 +347,21 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
 2. The board of the co-operative must consider each request for repurchase in accordance with the Law and cancel any shares that have been repurchased.
 
+
 #### 19 Transfer of shares (CNL ss100 & 101)
 
-1. A share may not be sold or transferred, except when Rule 23 applies.
+1. A share may not be sold or transferred.
+
+
+#### 20 Effect of sale, transfer or disposal of shares (CNL ss232 & 233)  
+A member who has sold  or transferred, or disposed of the beneficial interest in, all the member’s shares, or  
+has agreed to do any of those things, is not entitled to vote at any meeting of the co-operative.
+
 
 
 ### Division 5 Member cancellations
 
-#### 20 Forfeiture and cancellations—inactive members (CNL ss156–163)
+#### 21 Forfeiture and cancellations—inactive members (CNL ss156–163)
 
 1. The board must declare the membership of a member cancelled if:
 
@@ -344,7 +369,8 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
     b) the member is not presently active and has not been active within the meaning of rule 4 in the past month.
     
-#### 21 Forfeiture of shares (CNL s109)
+    
+#### 22 Forfeiture of shares (CNL s109)
 
 1. If a member fails to pay a call or instalment of a call by the day appointed for payment, the board may, at any time that any part of the call or instalment remains unpaid, serve a notice on the member requiring payment of so much of the call or instalment as is unpaid, together with any interest that may have accrued.
 
@@ -356,18 +382,20 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
 5. Forfeited shares must be cancelled.
 
-#### 22 Forfeited shares—liability of members
+
+#### 23 Forfeited shares—liability of members
 
 1. A person whose shares have been forfeited under these rules stops being a member if membership is conditional on the holding of the shares or membership has otherwise been cancelled under the Law. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by him or her to the co-operative for the shares.
 
-2. A statutory declaration in writing by a director, the chief executive officer or secretary of the co- operative stating that a share in the co-operative has been forfeited and cancelled on a date stated in the declaration, is proof of that fact as against all persons claiming to be entitled to the share.
+2. A statutory declaration in writing by a director, the chief executive officer or secretary of the co-operative stating that a share in the co-operative has been forfeited and cancelled on a date stated in the declaration, is proof of that fact as against all persons claiming to be entitled to the share.
 
 3. The co-operative has set-off rights against share capital as specified in section 127 of the Law.
 
 
+
 ### Division 6 Deceased or incapacitated members
 
-#### 23 Death of member (CNL ss93 & 102–106)
+#### 24 Death of member (CNL ss93 & 102–106)
 
 The legal personal representative of a deceased member may apply to the board for a transfer of the deceased member’s shares in the following form:
 
@@ -391,7 +419,7 @@ The legal personal representative of a deceased member may apply to the board fo
  >  _In the presence of<span style="text-decoration:underline;"> 		</span>witness._
 
 
-#### 24 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
+#### 25 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
 
 1. A person’s membership ceases upon bankruptcy and that person’s shares may be transferred to the Official Trustee in Bankruptcy and dealt with under the provisions of section 95 of the Law.
 
@@ -401,7 +429,8 @@ The legal personal representative of a deceased member may apply to the board fo
 
 4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the member’s physical or mental infirmity is temporary.
 
-#### 25 Entitlements and liabilities of person registered as trustee, administrator etc.
+
+#### 26 Entitlements and liabilities of person registered as trustee, administrator etc.
 
 1. A person becoming entitled to be a shareholder because of the death, bankruptcy or incapacity of the holder is entitled to the dividends and other advantages to which the person would be entitled if he or she were the registered holder of the share or shares. However, before being registered as a member, the person is not entitled to exercise any right conferred by membership in relation to meetings of the co-operative.
 
@@ -410,9 +439,10 @@ The legal personal representative of a deceased member may apply to the board fo
 3. The board has the same right to decline or to suspend registration of a share as it would have had for a transfer of a share by the bankrupt or incapacitated person before the bankruptcy or incapacity.
 
 
+
 ### Division 7 Transfer of securities other than shares
 
-#### 26 Transfer and transmission of debentures
+#### 27 Transfer and transmission of debentures
 
 1. On the written request of the transferor (the giver) of a debenture, the co-operative must enter in the appropriate register the name of the transferee (the receiver) in the same way and on the same conditions as if the application for entry were made by the transferee.
 
@@ -446,37 +476,41 @@ The legal personal representative of a deceased member may apply to the board fo
 >
 >    _Signed by<span style="text-decoration:underline;"> 	</span>transferor. In the presence of<span style="text-decoration:underline;"> 		</span>witness. Signed by<span style="text-decoration:underline;"> 		</span>transferee. In the presence of<span style="text-decoration:underline;"> 			</span>witness._
 
-#### 27 Issue of CCUs (CNL ss345–354)
+
+#### 28 Issue of CCUs (CNL ss345–354)
 
 1. The board may not confer interests in the capital of the co-operative by issuing CCUs.
 
-#### 28 Transfer and transmission of CCUs
+
+#### 29 Transfer and transmission of CCUs
 
 1. Subject to subrule (2), the transfer and transmission of a CCU is to follow the same process as for a debenture under rule 27.
 
 2. If the terms of issue of a CCU differ from rule 27 in respect of the manner of transfer or transmission, the terms of its issue prevail.
 
 
+
 ## Part 3 General meetings, resolutions and voting
 
-#### 29 Annual general meeting (CNL s252)
+#### 30 Annual general meeting (CNL s252)
 
 An annual general meeting must be held each year, at a place and on a date and a time decided by the board, within 5 months after the close of the financial year of the co-operative or within the further time allowed by the Registrar.
 
-#### 30 Members’ power to requisition a general meeting (CNL s257)
+
+#### 31 Members’ power to requisition a general meeting (CNL s257)
 
 1. The board may, whenever it considers appropriate, call a special general meeting of the co-operative.
 
-2. The board must call a general meeting of the co-operative on the requisition in writing by members who together are able to cast at least 20%_ _of the total number of votes able to be cast at a meeting of the co-operative.
+2. The board must call a general meeting of the co-operative on the requisition in writing by members who together are able to cast at least 20% of the total number of votes able to be cast at a meeting of the co-operative.
 
 3. The provisions of section 257 of the Law apply to a meeting requisitioned by members.
 
-#### 31 Notice of general meetings (CNL ss239, 254 & 611)
+
+#### 32 Notice of general meetings (CNL ss239, 254 & 611)
 
 1. At least 14 days’ notice of a general meeting (not including the day on which the notice is served or taken to be served, but including the day for which notice is given) must be given.
 
 > **Note 1.** If there is to be a special resolution proposed at the meeting, there is a requirement for at least 21 days’ notice of the special resolution.
-
 
 > **Note 2.** If there is a resolution proposed for the removal of a director, section 180 of the Law requires special notice of the resolution and 21 days’ notice of the meeting.
 
@@ -492,14 +526,14 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 > **Note 1.** Section 611 of the Law makes provision for the service of notices on members of the co-operative. Rule 62 makes additional provision for notice by electronic transmission.
 
-
 > **Note 2.** Non-receipt of the notice does not invalidate the proceedings at the general meeting.
 
 6. Members who together are able to cast at least 20 % of the total number of votes that are able to be cast at a meeting of the co-operative and who have a resolution to submit to a general meeting must give written notice of it to the co-operative at least 45 days before the day of the meeting.
 
 >**Note.** A co-operative can limit an individual member from proposing a resolution to the general meeting by requiring that there be a minimum number of members proposing the resolution before the matter can be considered. This does not prevent an individual member from requesting that the board propose a particular resolution at the next meeting.
 
-#### 32 Business of general meetings
+
+#### 33 Business of general meetings
 
 1. The ordinary business of the annual general meeting of a large co-operative must be:
 
@@ -529,9 +563,7 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 >**Note 1.** A small co-operative must prepare and send to members minimum financial statements that are specified in regulation 3.10 of the National Regulations (these are referred as “basic minimum financial statements”). A co-operative may require more than the basic minimum financial statements to be provided to members and, if so, the additional financial statements should be specified in this rule.
 
-
 >**Note 2.** If the small co-operative has consolidated gross assets of less than $250,000 and consolidated revenue of less than $750,000, the financial statement for the small co-operative need not include a cash flow statement (as provided in regulation 3.10 of the National Regulations).
-
 
 >**Note 3.** A small co-operative may decide whether its financial statements are to be either audited or reviewed, or neither.
 
@@ -539,7 +571,8 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 4. All business of a general meeting, other than business of the annual general meeting that is ordinary business, is special business.
 
-#### 33 Quorum at general meetings
+
+#### 34 Quorum at general meetings
 
 1. An item of business cannot be transacted at a general meeting unless a quorum of members is present when the meeting is considering the item.
 
@@ -549,7 +582,8 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 4. If a quorum is not present within half an hour after the time appointed for an adjourned meeting, the members present constitute a quorum.
 
-#### 34 Chairperson at general meetings
+
+#### 35 Chairperson at general meetings
 
 1. The chairperson, if any, of the board may preside as chairperson at every general meeting of the co-operative.
 
@@ -558,7 +592,7 @@ An annual general meeting must be held each year, at a place and on a date and a
 3. The chairperson may, with the consent of a meeting at which a quorum is present (and must if directed by the meeting) adjourn the meeting from time to time and from place to place. However, the only business that can be transacted at an adjourned meeting is the business left unfinished at the meeting from which the adjournment took place. When a meeting is adjourned for 14 days or more, notice of the adjourned meeting must be given just as for the original meeting. Apart from this it is not necessary to give notice of an adjournment or the business to be transacted at an adjourned meeting.
 
 
-#### 35 Attendance and voting at general meetings (CNL ss228 & 256)
+#### 36 Attendance and voting at general meetings (CNL ss228 & 256)
 
 1. The right to vote attaches to membership and not shareholding.
 
@@ -590,9 +624,11 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 12. The result of the vote must be entered in the minute book.
 
-#### 36 Voting on a show of hands (CNL ss234 & 256)
+
+#### 37 Voting on a show of hands (CNL ss234 & 256)
 
 1. On a show of hands at a general meeting, each member:
+
     a) present; or
     
     b) represented by a non-member acting under a power of attorney; or
@@ -601,7 +637,8 @@ An annual general meeting must be held each year, at a place and on a date and a
     
     d) represented by a proxy (but only if proxies are allowed under these rules); may exercise only one vote.
    
-#### 37 Voting on a poll
+   
+#### 38 Voting on a poll
 
 1. On a poll called at a general meeting, each member:
 
@@ -615,10 +652,10 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 > **Note 1.** A person can hold an unlimited number of proxies unless the rules restrict the number of proxies any one person can hold. If the vote on a show of hands is likely not to represent the views of the members who have given a proxy, a poll may be demanded. Section 256(2) of the Law provides that a question is to be decided by a poll if a poll is required by the chairperson of the meeting or by any 5 members present at the meeting or represented at the meeting by proxy.
 
-
 > **Note 2.** Most decisions are made by ordinary resolution, but in certain cases the Law requires a special resolution.
 
-#### 38 Determining the outcome where equality of votes (s228)
+
+#### 39 Determining the outcome where equality of votes (s228)
 
 1. This rule applies where the votes in favour and against a resolution are equal.
 
@@ -626,11 +663,13 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 3. If the chairperson is not a member of the co-operative or decides not to exercise a second or casting vote, the outcome of an equality of votes is taken to have been decided in the negative.
 
-#### 39 Proxy votes (s229)
+
+#### 40 Proxy votes (s229)
 
 Voting by proxy is not permitted at a general meeting. 
 
-#### 40 Postal ballots (other than special postal ballots) (CNL ss247 & 250)
+
+#### 41 Postal ballots (other than special postal ballots) (CNL ss247 & 250)
 
 > **Note.** Section 250 of the Law provides that members may require a matter to be decided by a postal ballot. The following rule will facilitate a postal ballot in these situations.
 
@@ -660,7 +699,8 @@ Voting by proxy is not permitted at a general meeting.
 
 8. This rule does not apply in relation to special postal ballots.
 
-#### 41 Special postal ballots (CNL ss248 & 249)
+
+#### 42 Special postal ballots (CNL ss248 & 249)
 
 > **Note.** A special postal ballot is required by the Law for certain specified decisions. The majority required to pass a special postal ballot is 75%. A special postal ballot is governed by the provisions of the Law and the National Regulations as well as these rules.
 
@@ -672,7 +712,8 @@ Voting by proxy is not permitted at a general meeting.
 
 4. If the board decides to conduct a secret postal ballot, it must ensure that the method used to conduct the ballot will ensure that votes can be counted without identifying the way each member has voted.
 
-#### 42 Special resolutions (CNL ss238–241)
+
+#### 43 Special resolutions (CNL ss238–241)
 
 1. A special resolution is a resolution that is passed:
 
@@ -698,14 +739,16 @@ Voting by proxy is not permitted at a general meeting.
 
 ## Part 4 Board of directors
 
-#### 43 Board (CNL s172)
+#### 44 Board (CNL s172)
+
 1. The business of the co-operative is to be managed by or under the direction of the board of directors, and for that purpose the board has and may exercise all the powers of the co-operative that are not required to be exercised by the co-operative in general meeting.
 
 >**Note.** The rules of the co-operative may restrict the power of the board, but an exercise of power by the board in excess of the restriction in these rules may still be a valid act. See section 45 of the Law.
 
 2. The board must have a minimum of 3 directors.
 
-#### 44 Qualifications of directors (CNL s174)
+
+#### 45 Qualifications of directors (CNL s174)
 
 1. A person is not qualified to be a director of the co-operative unless the person is an individual over the age of 18 years and is either:
 
@@ -717,7 +760,8 @@ Voting by proxy is not permitted at a general meeting.
 
 3. The board of directors must have a majority of member directors.
 
-#### 45 Chief executive officer (CNL ss172 & 178)
+
+#### 46 Chief executive officer (CNL ss172 & 178)
 
 1. The board may, if it considers appropriate, appoint a person to be responsible for the day to day management of the co-operative. The person may be a director or the secretary or a member of the co- operative or some other person.
 
@@ -731,7 +775,8 @@ Voting by proxy is not permitted at a general meeting.
 
 6. In the event of any conflict between the terms of the appointment of a person as the chief executive officer and that person’s obligations or privileges under the Law, the terms of the Law prevail over the terms of appointment.
 
-#### 46 First directors and election of directors (CNL ss173 & 179)
+
+#### 47 First directors and election of directors (CNL ss173 & 179)
 
 1. The first directors are elected by poll at the formation meeting of the co-operative (except as provided by section 173(2)(b) of the Law).
 
@@ -796,15 +841,18 @@ Voting by proxy is not permitted at a general meeting.
 
 9. If any vacancies remain at the end of the meeting, the vacancies are to be casual vacancies and must be filled in accordance with rule 50.
 
-#### 47 Removal from office of director (CNL s180)
+
+#### 48 Removal from office of director (CNL s180)
 
 The co-operative may by resolution under section 180 of the Law, with special notice as required by that section, remove a director before the end of the director’s period of office, and may by a simple majority appoint another person in place of the removed director. The person appointed must retire when the removed director would otherwise have retired.
 
-#### 48 Vacation of office of director (CNL s179)
+
+#### 49 Vacation of office of director (CNL s179)
 
 In addition to the circumstances set out in the Law, a director vacates office if the director dies.
 
-#### 49 Casual vacancies and alternate directors (CNL ss173 & 177)
+
+#### 50 Casual vacancies and alternate directors (CNL ss173 & 177)
 
 1. The board may appoint a qualified person to fill a casual vacancy in the office of director until the next annual general meeting.
 
@@ -824,7 +872,8 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
     b) if the alternate director is removed from office by the board as alternate director for failure, without its leave, to attend a meeting of the board at which the principal director is absent (and for that purpose the provisions of section 179(2)(b) of the Law do not apply in relation to the alternate director).
 
-#### 50 Remuneration of directors (CNL s203)
+
+#### 51 Remuneration of directors (CNL s203)
 
 Directors’ remuneration must comply with the provisions of the Law.
 
@@ -832,7 +881,8 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 > **Note 2.** An alternate director is treated as a director under the Law, and remuneration of an alternate director is subject to the same restrictions under the Law.
 
-#### 51 Proceedings of the board (CNL ss175 & 176)
+
+#### 52 Proceedings of the board (CNL ss175 & 176)
 
 1. Meetings of the board (including meetings conducted outside board meetings pursuant to section 176 of the Law) are to be held as often as may be necessary for properly conducting the business of the co- operative and must be held at least every 3 months.
 
@@ -844,13 +894,15 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 5. Other than in special circumstances decided by the chairperson, at least 48 hours notice must be given to the directors of all meetings of the board, without which the meeting cannot be held.
 
-####  52 Quorum for board meetings (CNL s175)
+
+####  53 Quorum for board meetings (CNL s175)
 
 1. The quorum for a meeting of the board is 50% of the number of directors (or if that percentage of the number of directors is not a whole number, the whole number next higher than one half).
 
 2. For a quorum, the number of member directors must outnumber the non-member directors by at least one.
 
-#### 53 Chairperson of board
+
+#### 54 Chairperson of board
 
 1. The chairperson of the board is to be elected by the board.
 
@@ -864,7 +916,8 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 >**Note.** Subrule (3) does not affect the requirements of section 180 of the Law in respect of the removal of a director.
 
-#### 54 Delegation and board committees (CNL s178)
+
+#### 55 Delegation and board committees (CNL s178)
 
 1. The board may by resolution delegate to:
 
@@ -892,7 +945,8 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 7. A committee may meet and adjourn as it thinks appropriate. Questions arising at a meeting must be decided by a majority of votes of the members present and voting and if the votes are equal, the chairperson has a second or casting vote.
 
-####  55 Other committees
+
+####  56 Other committees
 
 1. The board may by resolution appoint committees of members or other persons or both, to act in an advisory role to the board and to committees of directors.
 
@@ -900,7 +954,8 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 3. The quorum for a meeting of the committee is half the number of committee members (or, if half is not a whole number, the whole number next higher than one half).
 
-#### 56 Minutes
+
+#### 57 Minutes
 
 1. The board must keep minutes of meetings and, in particular, of:
 
@@ -913,12 +968,14 @@ Directors’ remuneration must comply with the provisions of the Law.
 > **Note.** Section 209 of the Law also requires any declarations of interest by directors to be recorded in the minutes.
 
 2. Minutes must be entered in the appropriate records within 28 days of the meeting to which they relate was held.
+
 3. The minutes are to be signed within a reasonable time after the meeting to which they relate by either the chairperson of that meeting or the chairperson of the next meeting.
+
 
 
 ## Part 5 Rules
 
-#### 57 Amendments and copies of rules (CNL ss57 & 60–63)
+#### 58 Amendments and copies of rules (CNL ss57 & 60–63)
 
 1. Any amendment of the rules must be approved by special resolution. However, if model rules are adopted in the manner specified under section 65(a) of the Law, any amendments to the model rules as notified by the Registrar are included in the co-operative’s rules without the need for a special resolution.
 
@@ -931,9 +988,10 @@ Directors’ remuneration must comply with the provisions of the Law.
 > **Note.** The rule could instead provide that the fee payable by a member for a copy of the rules is nil (for example, for a copy that is provided electronically to the member). In any case, the fee cannot be greater than the fee that would be charged if the member obtained a copy from the Registrar.
 
 
+
 ## Part 6 Administrative matters
 
-#### 58 Seal (CNL ss49 & 223)
+#### 59 Seal (CNL ss49 & 223)
 
 1. This rule applies if the co-operative chooses to authenticate a document under the common seal of the co-operative.
 
@@ -943,7 +1001,8 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 4. The seal of the co-operative must not be affixed to an instrument other than under a resolution of the board. Two directors, or one director and the secretary, must be present and must sign all instruments sealed while they are present.
 
-#### 59 Inspection of records and registers (CNL ss214 & 215)
+
+#### 60 Inspection of records and registers (CNL ss214 & 215)
 
 1. Members of the co-operative have free access to the records and registers referred to in section 214 of the Law and they may make a copy of any entry in the registers free of charge.
 
@@ -953,11 +1012,13 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 2. Members do not have access to the minutes of board or committee meetings, but may request access to any such minutes in writing addressed to the board.
 
-#### 60 Safe keeping of securities
+
+#### 61 Safe keeping of securities
 
 Shares, debentures, charges and any other certificates or documents or duplicates of them pertaining to securities must be safely kept by the co-operative in the way and with the provision for their security as the board directs.
 
-#### 61 Notices to members (CNL s611)
+
+#### 62 Notices to members (CNL s611)
 
 1. This rule applies in addition to section 611 of the Law regarding how a notice or other document may be given to a member of the co-operative.
 
@@ -978,11 +1039,12 @@ Shares, debentures, charges and any other certificates or documents or duplicate
 
 ## Part 7 Accounting and financial matters
 
-#### 62 Financial year
+#### 63 Financial year
 
 The financial year of the co-operative ends on June 30<sup>th</sup>.
 
-#### 63 Accounts
+
+#### 64 Accounts
 
 1. The board must have at least one financial institution account, electronic or otherwise, in the name of the co-operative, into which all amounts received by the co-operative must be paid as soon as possible after receipt.
 
@@ -996,13 +1058,54 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
    
     b) a person approved by the board.
 
-#### 64 Appointing an auditor or reviewer for a small co-operative if there is a direction under the Law (CNL ss271 & 272)
+
+#### 65 Appointing an auditor or reviewer for small co-operative (optional rule) (CNL s298)  
+
+> **Note 1.**  If a co-operative is a small co-operative in a particular financial year, there is no requirement to appoint an auditor, unless the co-operative is directed to prepare audited or reviewed financial statements by its  members or by the Registrar. A small co-operative may choose to appoint an auditor or a reviewer to have its  
+financial statements to members either audited or reviewed each financial year where there is no direction  
+from members or the Registrar.  
+
+>**Note 2.**  A review may be carried out by a person who:
+>-  is a member of the Institute of Chartered Accountants in Australia and holds a Certificate of Public  
+Practice issued by that body  
+>-  is a member of CPA Australia Ltd and holds a Public Practice Certificate issued by that body  
+>-  is a member of the Institute of Public Accountants and holds a Professional Practice Certificate issued  
+by that body  
+
+>**Note 3.**  Large co-operatives are required to appoint an auditor in accordance with the procedures under the  
+Law. A large co-operative is one that is not classified as a small co-operative under the National Regulations.  
+
+>**Note 4.**  The following rule is suitable for a small co-operative that wishes to require its financial statements be  either audited or reviewed.  
+
+1. The co-operative must appoint an auditor / a reviewer  (strike out whichever is not applicable)  in  
+respect of its financial statements.  
+
+2. An auditor / a reviewer  (strike out whichever is not applicable)  appointed under this rule is to  
+conduct an audit / review  (strike out whichever is not applicable)  of the co-operative’s financial  
+statements as presented to members.  
+
+3. The appointment of an auditor / a reviewer  (strike out whichever is not applicable)  under this  
+rule is to be made at an annual general meeting.  
+
+4. The co-operative may appoint another auditor / reviewer  (strike out whichever is not applicable)  
+at a subsequent annual general meeting if there is a vacancy in the office of the auditor /  
+reviewer  (strike out whichever is not applicable).  
+
+5. The provisions of section 300(2) of the Law apply to an auditor / a reviewer  (strike out whichever  
+is not applicable)  appointed under this rule in the same way (but with any necessary adaptations)  
+as they apply to an auditor appointed for a large co-operative.
+
+>**Note.**  See section 310 of the Law regarding the removal and resignation of auditors.
+
+
+#### 66 Appointing an auditor or reviewer for a small co-operative if there is a direction under the Law (CNL ss271 & 272)
 
 1. If a small co-operative is directed to prepare a financial report under section 271 or 272 of the Law and the direction requires that the financial report be audited or reviewed, the board must appoint an auditor or reviewer (as the case may be) within one month of the direction.
 
 3. An auditor or reviewer appointed under this rule holds office until the financial report prepared as a result of the direction has been audited or reviewed and sent to members.
 
-#### 65 Disposal of surplus funds during a financial year (CNL ss355–358)
+
+#### 67 Disposal of surplus funds during a financial year (CNL ss355–358)
 
 1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law as determined by the board.
 
@@ -1010,23 +1113,32 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
 
 4. A part of the surplus, but no more than 70%, arising in a year from the business of the co-operative may be applied for any charitable purposes.
 
-#### 66 Provision for loss
+
+#### 68 Provision for loss
 
 The board must make appropriate provision for losses in the co-operative’s accounts and when reporting to members is to indicate whether the loss is expected to continue and whether there is any real prejudice to the co-operative’s solvency.
 
-#### 67 Financial reports to members (CNL Part 3.3)
+
+#### 69 Financial reports to members (CNL Part 3.3)
 
 The co-operative must prepare financial reports and statements in accordance with the Law, the National Regulations and these rules.
 
-
 >**Note.** The financial reports or statements required by the Law to be given to members vary according to the size of a co-operative in a given year. Large co-operatives are required to prepare and lodge with the Registrar full audited financial reports as set out in Part 3.3 of the Law. Small co-operatives are not required to lodge financial reports with the Registrar but are required to lodge an annual return under section 293 of the Law and provide
 
-## Part 8 Winding up
 
-#### 68 Winding up (CNL Part 4.5)
+
+## Part 8 Winding up and non-profit nature of the co-operative 
+
+#### 70 Winding up (CNL Part 4.5)
     
 1.  The winding up of the co-operative must be in accordance with Part 4.5 of the Law.
     
-2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operative’s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, and which has similar rules prohibiting the distribution of its assets and income to its members.
+2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operative’s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, which is charitable at law and which has rules prohibiting the distribution of its assets and income to its members.
 
-1.  If on the winding up or dissolution there is a deficiency, members are liable to contribute towards the deficiency to the extent of any amount unpaid on the shares held by the member and any charges payable by the member to the co-operative as required by these rules.
+3.  If on the winding up or dissolution there is a deficiency, members are liable to contribute towards the deficiency to the extent of any amount unpaid on the shares held by the member and any charges payable by the member to the co-operative as required by these rules.
+
+
+#### 71  Non-profit nature of the co-operative 
+
+1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative
+

--- a/Rules.md
+++ b/Rules.md
@@ -1,9 +1,10 @@
 
+
 ---
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 3
+Version 1.20: B.V Draft 4
 01/10/2022
 &nbsp;
 
@@ -269,6 +270,8 @@ A member may resign from a co-operative by giving two weeks’ notice in writing i
     a) written notice of intention to impose the fine and the reason for it has been given to the member; and
     
     b) the member has been given a reasonable opportunity to appear before the board in person (with or without witnesses), or to send to the board a written statement, to show cause why the fine should not be imposed.
+
+3. The board must waive a fine to a member if decided by way of ordinary resolution at a general meeting.
 
 
 #### 15 Liability of members to co-operatives (CNL ss117(2) & 121)
@@ -1027,30 +1030,15 @@ The co-operative must prepare financial reports and statements in accordance wit
 
 ## Part 9 Policies of the co-operative
 
-#### 72  Effect of policies @(Alternate A)
-
-1. The policies of the co-operative have the effect of a contract under seal—  
-
-    a)  between the co-operative and each member; and 
-
-    b)  between the co-operative and each director, the chief executive officer and  
-the secretary of the co-operative; and 
-
-    c)  between a member and each other member.  
-    
-2.  Under the contract, each of those persons agrees to observe and perform the  
-provisions of the policies as in force for the time being so far as those provisions apply to  
-the person.
-
-
-#### 72  Effect of policies @(Alternate B)
+#### 72  Effect of policies 
 
 1. The co-operative, as well as each member, director, officer and the secretary of the co-operative, must abide by the policies of the co-operative.
 
-2. The policies of the co-operative may conditionally or unconditionally limit the powers of, or restrict or dictate the decisions which may be made by, the co-operative, as well as each member, director, officer or the secretary of the co-operative.
+2. The policies of the co-operative may conditionally or unconditionally limit the powers of, or restrict or dictate the decisions or resolutions which may be made by, the co-operative, as well as each member, director, officer or the secretary of the co-operative.
 
-3. The policies may set out punitive measures if not followed, such as the imposition of fines or the suspension and expulsion of members
+3. The policies may prescribe specific situations where members shall be or suspended or expelled. 
 
+4. An ordinary resolution may overturn or repeal a suspension or expellation of a member, but only if a policy was the sole mechanism of suspension or expellation. 
 
 #### 73  Limitations of policies
 
@@ -1060,25 +1048,24 @@ the person.
 
 3. The cooperative may not approve any policy which, if that policy were a rule amendment, would not be permitted without prior approval of the Registrar under the Law.
 
->**Note.** Section 60 of the law prohibits certain Rule ammendments without prior approval from the Registrar
+>**Note.** Section 60 of the law prohibits certain Rule ammendments without prior approval from the Registrar, such as conversion of the cooperative or changes to the active membership provisions.
 
 
-#### 74  Provisions for the sanction of policies and first policy
+#### 74  Provisions for the execution of policies and first policy
 
 1. The first policy (The Policies Policy) of the co-operative must set out:
    
    a) the general form of policies;
    
-   b) how additional policies are to be sanctioned and ammended.
+   b) how additional policies may be executed and ammended.
 
-2. The first policy of the co-operative may be sanctioned by an ordinary resolution.
+2. The first policy of the co-operative may be executed by an ordinary resolution at a general meeting.
 
-3. Ammendments to the first policy cannot be made by ordinary resolution, unless allowed by a provision of the first policy.
+3. Ammendments to the first policy cannot be executed by an ordinary resolution, unless permitted by a provision of the first policy.
 
-4. Ammendments to the first policy may be made by special resolution.
+4. Ammendments to the first policy may be executed by way of special resolution.
 
 
 #### 75  Availability of policies
 
 The policies must be made available to all prospective members of the co-operative, and a copy of any policy must be provided to members if requested alongside the rules when provided under rule 58 (3).
-

--- a/Rules.md
+++ b/Rules.md
@@ -1,9 +1,10 @@
+
 ---
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 6
-05/10/2022
+Version 1.20: B.V Draft 7
+10/10/2022
 &nbsp;
 
 Adopted by the co-operative at a general meeting on: 
@@ -27,12 +28,9 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 
    **ballot paper** means a ballot paper in paper or electronic form.
 
-
-   **basic** minimum financial statements means the financial statement required of a small co-operative under the National Regulations.
-
+   **basic minimum financial statements** means the financial statement required of a small co-operative under the National Regulations.
 
    **board** means the board of the co-operative.
-
 
    **CNL** is a reference to the Co-operatives National Law as applying in this jurisdiction.
    
@@ -43,14 +41,12 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
    **member director and non-member director**—see section 174 of the Law and rule 45.
    
    **standard postal times** means the times when properly addressed and prepaid letters would be delivered in the ordinary course of post.
-
    
-   **the co-operative** means The Electric Boogaloo Co-operative Ltd.
+   the **co-operative** means The Electric Boogaloo Co-operative Ltd.
 
-   
-   **the Law** means the Co-operatives National Law as applying in this jurisdiction.
+   the **Law** means the Co-operatives National Law as applying in this jurisdiction.
 
-   the National **Regulations** means the Co-operatives National Regulations as applying in this jurisdiction.
+   the **National Regulations** means the Co-operatives National Regulations as applying in this jurisdiction.
 
 2. Except so far as the contrary intention appears in these rules, words and expressions used in these rules have the same meanings as they have, from time to time, in the Law or relevant provisions of the Law.
 
@@ -171,7 +167,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
 3. The shares of an expelled or resigning member must be cancelled as at the day of expulsion or resignation, and the cancellation must be noted in the register of shares.
 
-4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former member’s shares at the time of expulsion or resignation (less any amount owing by the former member to the co- operative).
+4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former member’s shares at the time of expulsion or resignation (less any amount owing by the former member to the co-operative).
 
 5. If a deficiency exists, an appropriate proportion of the loss, deficiency or significant change may be deducted from the amount of capital paid up on the shares of the expelled or resigning member. This is done having regard to the number of shares held by the expelled or resigning member immediately before expulsion or resignation in relation to the number of shares in the co-operative.
 
@@ -198,7 +194,7 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
     a) loses any rights (except the right to vote) arising as a result of membership; and
    
-    b) is not entitled to a refund, rebate, relief or credit for membership fees paid, or payable, to the co- operative; and
+    b) is not entitled to a refund, rebate, relief or credit for membership fees paid, or payable, to the co-operative; and
     
     c) remains liable for any fine that may be imposed.
 
@@ -678,7 +674,7 @@ Voting by proxy is not permitted at a general meeting.
 
 #### 46 Chief executive officer (CNL ss172 & 178)
 
-1. The board may, if it considers appropriate, appoint a person to be responsible for the day to day management of the co-operative. The person may be a director or the secretary or a member of the co- operative or some other person.
+1. The board may, if it considers appropriate, appoint a person to be responsible for the day to day management of the co-operative. The person may be a director or the secretary or a member of the co-operative or some other person.
 
 2. The appointed person is the chief executive officer of the co-operative, and may be called the chief executive officer or (if a director of the board) the managing director.
 
@@ -792,14 +788,14 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
 Directors’ remuneration must comply with the provisions of the Law.
 
-> **Note 1.** Remuneration for directors is strictly controlled under the Law and requires the approval of the co- operative in general meeting. However, it is possible for a co-operative to specify in its rules that a director will receive particular remuneration if this is appropriate. It may still be necessary to obtain ratification or approval at a general meeting even in respect of specified remuneration under the rules.
+> **Note 1.** Remuneration for directors is strictly controlled under the Law and requires the approval of the co-operative in general meeting. However, it is possible for a co-operative to specify in its rules that a director will receive particular remuneration if this is appropriate. It may still be necessary to obtain ratification or approval at a general meeting even in respect of specified remuneration under the rules.
 
 > **Note 2.** An alternate director is treated as a director under the Law, and remuneration of an alternate director is subject to the same restrictions under the Law.
 
 
 #### 52 Proceedings of the board (CNL ss175 & 176)
 
-1. Meetings of the board (including meetings conducted outside board meetings pursuant to section 176 of the Law) are to be held as often as may be necessary for properly conducting the business of the co- operative and must be held at least every 3 months.
+1. Meetings of the board (including meetings conducted outside board meetings pursuant to section 176 of the Law) are to be held as often as may be necessary for properly conducting the business of the co-operative and must be held at least every 3 months.
 
 2. A meeting may be held with one or more of the directors participating by using a form of communication that allows reasonably contemporaneous and continuous communication between the directors taking part in the meeting.
 
@@ -846,7 +842,7 @@ Directors’ remuneration must comply with the provisions of the Law.
 
     e)   a committee of directors and other persons;
 
-    the exercise of the board’s powers (other than this power of delegation) specified in the resolution. The co- operative or the board may by resolution revoke all or part of the delegation.
+    the exercise of the board’s powers (other than this power of delegation) specified in the resolution. The co-operative or the board may by resolution revoke all or part of the delegation.
 
 2. A power delegated under this rule may, while the delegation remains unrevoked, be exercised from time to time in accordance with the delegation.
 
@@ -1041,25 +1037,25 @@ operative, the rules may include additional financial statements or information.
 
 2. The policies of the co-operative may (conditionally or unconditionally) limit the powers of or restrict or dictate the decisions or resolutions of the co-operative, as well as each member, director, officer or the secretary of the co-operative.
 
-3. The policies may prescribe specific situations where members shall be or suspended or expelled. 
+3. The policies of the co-operative may prescribe specific situations where members shall be or suspended or expelled. 
 
 4. An ordinary resolution may overturn or repeal a suspension or expellation of a member, but only if a policy was the sole mechanism of suspension or expellation. 
 
 
 #### 73  Limitations of policies
 
-1. If a provision of the policies is inconsistent with a provision of the rules, the rules in that instance shall prevail.
+1. If a provision of any policy is inconsistent with a provision of the rules, the rules in that instance shall prevail.
 
-2. If a provision of the policies is inconsistent with a provision of the Law, the Law in that instance shall prevail.
+2. If a provision of any policy is inconsistent with a provision of the Law, the Law in that instance shall prevail.
 
-3. The cooperative may not approve any policy which, if that policy were a rule amendment, would not be permitted without prior approval of the Registrar under the Law.
+3. The cooperative may not approve any policy or amendment to a policy which, if that policy were a rule amendment, would not be permitted without prior approval of the Registrar under the Law.
 
 >**Note.** Section 60 of the law prohibits certain rule ammendments without prior approval from the Registrar, such as conversion of the cooperative or changes to the active membership provisions.
 
 
 #### 74  Provisions for the execution of policies and first policy
 
-1. The first policy (The Policies Policy) of the co-operative must include:
+1. The first policy of the co-operative must include:
    
    a) the general form of policies; and
    
@@ -1071,9 +1067,13 @@ operative, the rules may include additional financial statements or information.
 
 4. Amendments to the first policy cannot be executed by an ordinary resolution, unless permitted by a provision of the first policy.
 
-5. Amendments to the first policy may be executed by way of special resolution.
+5. Amendments to any part of any policy (including the first policy) may be executed by way of special resolution.
 
 
 #### 75  Availability of policies
 
-The policies must be made available to all prospective members of the co-operative, and a copy of any policy must be provided to members if requested alongside the rules when provided under rule 58 (3).
+1. In the same circumstances which the rules are ordinarily provided the co-operative must, upon the request of any person, provide a copy of the policies.
+
+2. All prospective members of the co-operative must be provided with the policies. 
+
+3. The policies may be provided electronically, including by providing a web address. 

--- a/Rules.md
+++ b/Rules.md
@@ -3,8 +3,8 @@
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 1
-20/09/2022
+Version 1.20: B.V Draft 2
+30/09/2022
 &nbsp;
 
 Adopted by the co-operative at a general meeting on: 
@@ -121,11 +121,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
     a) if the membership ceases in any circumstances specified in section 117 of the Law;
     
-    b) if the member’s total shareholding is forfeited under the Law or these rules;
-    
-    c) if the member’s total shareholding is purchased by the co-operative under the Law or these rules;
-    
-    d) if the member’s total shareholding is sold by the co-operative under any power in the Law or these rules and the purchaser is registered as shareholder in the member’s place.
+    b) if the member loses their share under these rules or the Law. 
     
     
 #### 9 Expulsion of members (CNL s117)
@@ -159,8 +155,6 @@ A person qualifies for membership of the co-operative if the person is able to u
 4. Expulsion of one joint member means expulsion of all members holding membership jointly with the expelled member.
 
 5. An expelled member must not be re-admitted as a member unless the re-admission is approved by special resolution.
-
-6. A member re-admitted must not have restored to him or her any shares that were cancelled on his or her expulsion.
 
 
 #### 10 Resignation of members (CNL s117)
@@ -303,59 +297,24 @@ A member may resign from a co-operative by giving two weeks’ notice in writing
 
 #### 17 Calls on shares
 
-1. The board may from time to time make calls on the members for any amounts unpaid on the shares of the members (whether on the nominal value of the shares or by way of premium), regardless of the share subscription amount (if any) specified in the terms of issue of the shares.
+No calls on shares will be made. 
 
-2. Each member must, on receiving at least 14 days’ notice of the time and place of payment, pay to the co-operative, at the time and place specified, the amount called on the shares.
-
-3. The directors may revoke or postpone a call.
-
-4. A call is taken to have been made when the resolution of the directors authorising the call was passed and may be required to be paid by instalments.
-
-5. The joint holders of a share are jointly and severally liable to pay all calls for the share.
-
-6. If an amount called for a share is not paid before or on the day fixed for payment of the amount, the person from whom the amount is due must pay interest on the amount from the day fixed for the payment of the amount to the time of actual payment at the rate, not more than 16% per annum, the directors decide, but the directors may waive payment of all or part of the interest.
-
-7. An amount that, under the terms of issue of a share, becomes payable on allotment or at a fixed date, whether on account of the nominal value of the share or by way of premium, is for these rules taken to be a call made and payable on the day that, under the terms of issue, the amount becomes payable. If the amount is not paid, all relevant provisions of these rules about payment of interest and expenses, forfeiture or otherwise apply as if the amount had become payable under a call properly made and notified.
-
-8. The board may, in relation to the issue of shares, differentiate between the holders in the amount of calls to be paid and the times of payment.
-
-9. The board may accept from a member all or part of the money uncalled and unpaid on shares held by the member.
- 
-10. The board may authorise payment by the co-operative of interest on all or part of an amount accepted under subrule (9) until the amount becomes payable, at a rate agreed between the board and the member paying the amount, of not more than 8% per annum or another rate fixed by the co-operative by special resolution.
+>**Note.** 100% of the value of shares must be paid in full at time of application
 
 
 #### 18 Repurchase of members’ shares (CNL ss99, 107, 109 & 118)
 
-1. Members’ shares may be repurchased by the co-operative in accordance with the Law.
-
-    A member who wishes the co-operative to repurchase any shares must do so by submitting a request to the board in the following form:
-
-
-    _I/We<span style="text-decoration:underline;"> 	</span>being members of the<span style="text-decoration:underline;"> 	</span>(co-operative name) and the holders of_
-
-
-    _<span style="text-decoration:underline;"> 	</span>(number of shares) in the co-operative that are fully/partly paid, request that the co-operative repurchase<span style="text-decoration:underline;"> 	</span>(number of shares). I/We are aware of the conditions of repayment under the Co- operatives National Law or relevant Act._
-
-
-    _Signed:  <span style="text-decoration:underline;"> 	</span>_
-
-
-    _Dated: <span style="text-decoration:underline;"> 	</span>_
-
-
-    _Witness (name and signature):_
-
-2. The board of the co-operative must consider each request for repurchase in accordance with the Law and cancel any shares that have been repurchased.
+A share may not be repurchased.
 
 
 #### 19 Transfer of shares (CNL ss100 & 101)
 
-1. A share may not be sold or transferred.
+A share may not be sold or transferred.
 
 
 #### 20 Effect of sale, transfer or disposal of shares (CNL ss232 & 233)  
-A member who has sold  or transferred, or disposed of the beneficial interest in, all the member’s shares, or  
-has agreed to do any of those things, is not entitled to vote at any meeting of the co-operative.
+
+A member who for any reason holds less than the minimum number of shares is not entitled to vote at any meeting of the co-operative, and their membership must be cancelled as soon as possible.
 
 
 
@@ -372,20 +331,14 @@ has agreed to do any of those things, is not entitled to vote at any meeting of 
     
 #### 22 Forfeiture of shares (CNL s109)
 
-1. If a member fails to pay a call or instalment of a call by the day appointed for payment, the board may, at any time that any part of the call or instalment remains unpaid, serve a notice on the member requiring payment of so much of the call or instalment as is unpaid, together with any interest that may have accrued.
+1. Forfeiture of shares includes forfeiture of all dividends declared for the forfeited shares and not actually paid before forfeiture.
 
-2. The notice must name a further day (not earlier than 14 days after the date of the notice) on or before which the payment required by the notice is to be made and must state that, in the event of non- payment at or before the time appointed, the shares for which the call was made will be liable to be forfeited
-
-3. If the requirements of the notice served under this rule are not complied with, any share in respect of which the notice has been given may at any time (but before the payment required by the notice has been made) be forfeited by a resolution of the board.
-
-4. Forfeiture of shares includes forfeiture of all dividends declared for the forfeited shares and not actually paid before forfeiture.
-
-5. Forfeited shares must be cancelled.
+2. Forfeited shares must be cancelled.
 
 
 #### 23 Forfeited shares—liability of members
 
-1. A person whose shares have been forfeited under these rules stops being a member if membership is conditional on the holding of the shares or membership has otherwise been cancelled under the Law. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by him or her to the co-operative for the shares.
+1. A person whose shares have been forfeited under these rules or the law stops being a member. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by them to the co-operative for the shares.
 
 2. A statutory declaration in writing by a director, the chief executive officer or secretary of the co-operative stating that a share in the co-operative has been forfeited and cancelled on a date stated in the declaration, is proof of that fact as against all persons claiming to be entitled to the share.
 
@@ -397,46 +350,26 @@ has agreed to do any of those things, is not entitled to vote at any meeting of 
 
 #### 24 Death of member (CNL ss93 & 102–106)
 
-The legal personal representative of a deceased member may apply to the board for a transfer of the deceased member’s shares in the following form:
-
-
->_I,<span style="text-decoration:underline;"> 	</span>am the legal personal representative of<span style="text-decoration:underline;"> 	</span>(a member of the co-operative) who died on <span style="text-decoration:underline;"> 		</span>_
->
->_Copies of my appointment as executor/administrator of the estate are attached._
->
->_I request that the board transfer all shares attaching to the membership of<span style="text-decoration:underline;"> 	</span>being shares numbered<span style="text-decoration:underline;"> 	</span>in the co-operative, to me._
->
->A) _I intend to hold the shares subject to the deceased member’s last will and testament / letters of administration and will notify the board of any proposal to transfer the shares to any beneficiary/ies 
->OR_
->B) _I am also the beneficiary of the estate of the deceased member and I am aware of the requirements for active membership under the rules of the co-operative._
->
- >(Include any additional information to enable the board to consider whether the transferee is likely to be an active member of the co-operative.)
- >
- > _Dated <span style="text-decoration:underline;"> 	</span>_
->
->   _Signed by<span style="text-decoration:underline;"> 	</span>Legal personal representative_
->
- >  _In the presence of<span style="text-decoration:underline;"> 		</span>witness._
-
+In the event that a member dies, their shares will be forfeited. 
 
 #### 25 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
 
-1. A person’s membership ceases upon bankruptcy and that person’s shares may be transferred to the Official Trustee in Bankruptcy and dealt with under the provisions of section 95 of the Law.
+1. A person’s membership ceases upon bankruptcy and that person’s shares must be forfeited.
 
 2. A person appointed under a law of a State or Territory to administer the estate of a member who, through mental or physical infirmity, is incapable of managing his or her affairs, may be registered as the holder of the member’s shares and the rights and liabilities of membership vest in that person during the period of the appointment.
 
-3. The liabilities attaching to the shares of a person under bankruptcy or mental incapacity continue in accordance with section 96 of the Law.
+3. The liabilities attaching to the shares of a person under mental incapacity continue in accordance with section 96 of the Law.
 
 4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the member’s physical or mental infirmity is temporary.
 
 
 #### 26 Entitlements and liabilities of person registered as trustee, administrator etc.
 
-1. A person becoming entitled to be a shareholder because of the death, bankruptcy or incapacity of the holder is entitled to the dividends and other advantages to which the person would be entitled if he or she were the registered holder of the share or shares. However, before being registered as a member, the person is not entitled to exercise any right conferred by membership in relation to meetings of the co-operative.
+1. A person becoming entitled to be a shareholder because of the incapacity of the holder is entitled to the dividends and other advantages to which the person would be entitled if he or she were the registered holder of the share or shares. However, before being registered as a member, the person is not entitled to exercise any right conferred by membership in relation to meetings of the co-operative.
 
-2. A person registered as holder of the shares of a member who has died, or is bankrupt or incapable of managing his or her affairs, has the same liabilities in relation to the share or shares as those to which the deceased, bankrupt or incapable person would have been liable if he or she had remained a member with full legal capacity.
+2. A person registered as holder of the shares of a member incapable of managing his or her affairs, has the same liabilities in relation to the share or shares as those to which the deceased, bankrupt or incapable person would have been liable if he or she had remained a member with full legal capacity.
 
-3. The board has the same right to decline or to suspend registration of a share as it would have had for a transfer of a share by the bankrupt or incapacitated person before the bankruptcy or incapacity.
+3. The board has the same right to decline or to suspend registration of a share as it would have had for a transfer of a share by the incapacitated person before the bankruptcy or incapacity.
 
 
 
@@ -458,35 +391,14 @@ The legal personal representative of a deceased member may apply to the board fo
     
     c) any government stamp duty payable is paid.
     
-5. Debentures must be transferred in the following form or in a form approved by the board: 
-
->    _I, A.B. (the transferor) of<span style="text-decoration:underline;"> 	</span>in the State/Territory of_
->
->    _<span style="text-decoration:underline;"> 	</span>in consideration of the sum of $<span style="text-decoration:underline;"> 	</span>paid_
->
->    _to me by C.D (the transferee), of .<span style="text-decoration:underline;"> 	</span>in the State of_
->
->    _<span style="text-decoration:underline;"> 	</span>transfer to the transferee the debenture(s) numbered_
->
->    _<span style="text-decoration:underline;"> 	</span>to be held by the transferee, the transferee’s executors, administrators and assigns, subject to any conditions on which I hold the debenture(s) and any other conditions being terms of the transfer of the debenture(s)._
->
->    _And I, the transferee, agree to take the debenture(s) subject to the conditions mentioned._
->
->    _Dated this<span style="text-decoration:underline;"> 	</span>. day of<span style="text-decoration:underline;"> 	</span>20 <span style="text-decoration:underline;"> 	</span>_
->
->    _Signed by<span style="text-decoration:underline;"> 	</span>transferor. In the presence of<span style="text-decoration:underline;"> 		</span>witness. Signed by<span style="text-decoration:underline;"> 		</span>transferee. In the presence of<span style="text-decoration:underline;"> 			</span>witness._
-
+5. Debentures must be transferred in a form approved by the board
 
 #### 28 Issue of CCUs (CNL ss345–354)
 
-1. The board may not confer interests in the capital of the co-operative by issuing CCUs.
+The board must not issue CCUs.
 
 
-#### 29 Transfer and transmission of CCUs
-
-1. Subject to subrule (2), the transfer and transmission of a CCU is to follow the same process as for a debenture under rule 27.
-
-2. If the terms of issue of a CCU differ from rule 27 in respect of the manner of transfer or transmission, the terms of its issue prevail.
+#### 29 Reserved
 
 
 
@@ -576,11 +488,13 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 1. An item of business cannot be transacted at a general meeting unless a quorum of members is present when the meeting is considering the item.
 
-2. Unless these rules state otherwise, 5 members (or 50% of total members entitled to vote rounded up to the nearest whole member, whatever is the lesser amount) present in person, each being entitled to exercise a vote, constitute a quorum.
+2. A member can be taken as being present "in person" if using a form of communication that allows reasonably contemporaneous and continuous communication between the other members taking part in the meeting.
 
-3. If a quorum is not present within half an hour after the appointed time for a meeting, the meeting, if called on the requisition of members, must be dissolved. In any other case it must be adjourned to the same day, time and place in the next week.
+3. Unless these rules state otherwise, 5 members (or 50% of total members entitled to vote rounded up to the nearest whole member, whatever is the lesser amount) present in person, each being entitled to exercise a vote, constitute a quorum.
 
-4. If a quorum is not present within half an hour after the time appointed for an adjourned meeting, the members present constitute a quorum.
+4. If a quorum is not present within half an hour after the appointed time for a meeting, the meeting, if called on the requisition of members, must be dissolved. In any other case it must be adjourned to the same day, time and place in the next week.
+
+5. If a quorum is not present within half an hour after the time appointed for an adjourned meeting, the members present constitute a quorum.
 
 
 #### 35 Chairperson at general meetings
@@ -983,7 +897,7 @@ Directors’ remuneration must comply with the provisions of the Law.
 
 2. A proposal to amend the rules of the co-operative must be made in a form approved by the board which clearly shows the existing rule or rules concerned and any proposed amendment to the rules.
 
-4. A member is entitled to a copy of the rules upon payment of the amount of $5 to the co-operative.
+3. A member is entitled to a copy of the rules upon payment of the amount of $5 to the co-operative.
 
 > **Note.** The rule could instead provide that the fee payable by a member for a copy of the rules is nil (for example, for a copy that is provided electronically to the member). In any case, the fee cannot be greater than the fee that would be charged if the member obtained a copy from the Registrar.
 
@@ -1022,15 +936,17 @@ Shares, debentures, charges and any other certificates or documents or duplicate
 
 1. This rule applies in addition to section 611 of the Law regarding how a notice or other document may be given to a member of the co-operative.
 
-3. A notice or other document required to be given to a member of the co-operative may be given by the co-operative to any member by any form of technology (for example, by fax or email), where the member has given consent and notified the co-operative of the relevant contact details.
+2. A notice or other document required to be given to a member of the co-operative may be given by the co-operative to any member by any form of technology (for example, by fax or email), where the member has given consent and notified the co-operative of the relevant contact details.
 
 >**Note.** Legislation relating to electronic transactions may also be relevant to the giving of notices or other documents.
 
-4. If a notice is sent by post, service is taken to be effected at the time at which the properly addressed and prepaid letter would be delivered in the ordinary course of post. In proving service by post, it is sufficient to prove that the envelope containing the notice was properly addressed and posted.
-5. A notice forwarded by some other form of technology is taken to have been served, unless the sender is notified of a malfunction in transmission, on the day of transmission if transmitted during a business day, otherwise on the next following business day.
-6. A notice may be given by the co-operative to joint members by giving the notice to the joint member named first in the register of members.
+3. If a notice is sent by post, service is taken to be effected at the time at which the properly addressed and prepaid letter would be delivered in the ordinary course of post. In proving service by post, it is sufficient to prove that the envelope containing the notice was properly addressed and posted.
 
-7. A notice may be given by the co-operative to the person entitled to a share in consequence of the death, incapacity or bankruptcy of a member by sending it through the post in a prepaid letter addressed to that person by name. Alternatively, it can be addressed to the person by the title of representative of the deceased or incapacitated person, or trustee of the bankrupt, or by any like description, and:
+4. A notice forwarded by some other form of technology is taken to have been served, unless the sender is notified of a malfunction in transmission, on the day of transmission if transmitted during a business day, otherwise on the next following business day.
+
+5. A notice may be given by the co-operative to joint members by giving the notice to the joint member named first in the register of members.
+
+6. A notice may be given by the co-operative to the person entitled to a share in consequence of the death, incapacity or bankruptcy of a member by sending it through the post in a prepaid letter addressed to that person by name. Alternatively, it can be addressed to the person by the title of representative of the deceased or incapacitated person, or trustee of the bankrupt, or by any like description, and:
 
     a) the address should be that supplied for the purpose by the person claiming to be entitled; or
     
@@ -1059,50 +975,14 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
     b) a person approved by the board.
 
 
-#### 65 Appointing an auditor or reviewer for small co-operative (optional rule) (CNL s298)  
-
-> **Note 1.**  If a co-operative is a small co-operative in a particular financial year, there is no requirement to appoint an auditor, unless the co-operative is directed to prepare audited or reviewed financial statements by its  members or by the Registrar. A small co-operative may choose to appoint an auditor or a reviewer to have its  
-financial statements to members either audited or reviewed each financial year where there is no direction  
-from members or the Registrar.  
-
->**Note 2.**  A review may be carried out by a person who:
->-  is a member of the Institute of Chartered Accountants in Australia and holds a Certificate of Public  
-Practice issued by that body  
->-  is a member of CPA Australia Ltd and holds a Public Practice Certificate issued by that body  
->-  is a member of the Institute of Public Accountants and holds a Professional Practice Certificate issued  
-by that body  
-
->**Note 3.**  Large co-operatives are required to appoint an auditor in accordance with the procedures under the  
-Law. A large co-operative is one that is not classified as a small co-operative under the National Regulations.  
-
->**Note 4.**  The following rule is suitable for a small co-operative that wishes to require its financial statements be  either audited or reviewed.  
-
-1. The co-operative must appoint an auditor / a reviewer  (strike out whichever is not applicable)  in  
-respect of its financial statements.  
-
-2. An auditor / a reviewer  (strike out whichever is not applicable)  appointed under this rule is to  
-conduct an audit / review  (strike out whichever is not applicable)  of the co-operative’s financial  
-statements as presented to members.  
-
-3. The appointment of an auditor / a reviewer  (strike out whichever is not applicable)  under this  
-rule is to be made at an annual general meeting.  
-
-4. The co-operative may appoint another auditor / reviewer  (strike out whichever is not applicable)  
-at a subsequent annual general meeting if there is a vacancy in the office of the auditor /  
-reviewer  (strike out whichever is not applicable).  
-
-5. The provisions of section 300(2) of the Law apply to an auditor / a reviewer  (strike out whichever  
-is not applicable)  appointed under this rule in the same way (but with any necessary adaptations)  
-as they apply to an auditor appointed for a large co-operative.
-
->**Note.**  See section 310 of the Law regarding the removal and resignation of auditors.
+#### 65 Reserved
 
 
 #### 66 Appointing an auditor or reviewer for a small co-operative if there is a direction under the Law (CNL ss271 & 272)
 
 1. If a small co-operative is directed to prepare a financial report under section 271 or 272 of the Law and the direction requires that the financial report be audited or reviewed, the board must appoint an auditor or reviewer (as the case may be) within one month of the direction.
 
-3. An auditor or reviewer appointed under this rule holds office until the financial report prepared as a result of the direction has been audited or reviewed and sent to members.
+2. An auditor or reviewer appointed under this rule holds office until the financial report prepared as a result of the direction has been audited or reviewed and sent to members.
 
 
 #### 67 Disposal of surplus funds during a financial year (CNL ss355–358)
@@ -1111,7 +991,7 @@ as they apply to an auditor appointed for a large co-operative.
 
 2. A part of the surplus, but no less than 30%, arising in a year from the business of the co-operative shall be retained to later be applied for the benefit of the co-operative.
 
-4. A part of the surplus, but no more than 70%, arising in a year from the business of the co-operative may be applied for any charitable purposes.
+3. A part of the surplus, but no more than 70%, arising in a year from the business of the co-operative may be applied for any charitable purposes.
 
 
 #### 68 Provision for loss
@@ -1141,4 +1021,4 @@ The co-operative must prepare financial reports and statements in accordance wit
 #### 71  Non-profit nature of the co-operative 
 
 1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative
-
+title: Rules of The Electric Boogaloo Co-operative Ltd.

--- a/Rules.md
+++ b/Rules.md
@@ -3,8 +3,8 @@
 title: Rules of The Electric Boogaloo Co-operative Ltd.
 ---
 
-Version 1.20: B.V Draft 2
-30/09/2022
+Version 1.20: B.V Draft 3
+01/10/2022
 &nbsp;
 
 Adopted by the co-operative at a general meeting on: 
@@ -41,7 +41,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 
    **member** means a member of the co-operative.
    
-   **member director and non-member director**â€”see section 174 of the Law and rule 45.
+   **member director and non-member director**—see section 174 of the Law and rule 45.
    
    **standard postal times** means the times when properly addressed and prepaid letters would be delivered in the ordinary course of post.
 
@@ -56,7 +56,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 2. Except so far as the contrary intention appears in these rules, words and expressions used in these rules have the same meanings as they have, from time to time, in the Law or relevant provisions of the Law.
 
 
-#### 3 Name and primary activity of the co-operative (CNL ss220â€“222 & 224)
+#### 3 Name and primary activity of the co-operative (CNL ss220–222 & 224)
 
 1.  The name of the co-operative is The Electric Boogaloo Co-operative Ltd.
 
@@ -71,7 +71,7 @@ These rules are the rules of The Electric Boogaloo Co-operative Ltd.
 ### Division 1 Membership generally
 
 
-#### 4 Active membership provisions (CNL ss112(2), 144, 148 & 156â€“166)
+#### 4 Active membership provisions (CNL ss112(2), 144, 148 & 156–166)
 
 1. Primary activity 
 
@@ -98,7 +98,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 #### 7 Membership applications
 
-1. Applications for membership must be lodged at the registered office in the application form approved by the board, and should be accompanied by:
+1. Applications for membership must be lodged in a form approved by the board, and should be accompanied by:
 
     a) payment of any applicable entry fee or subscription set under rule 6; and
     
@@ -106,7 +106,7 @@ A person qualifies for membership of the co-operative if the person is able to u
   
 2. Every application must be considered by the board.
 
-3. If the board approves the application, the applicantâ€™s name and any other information required under the Law must be entered in the register of members within 28 days of the boardâ€™s approval.
+3. If the board approves the application, the applicant’s name and any other information required under the Law must be entered in the register of members within 28 days of the board’s approval.
 
 4. The applicant must be notified in writing of the entry in the register and the applicant is then entitled to the privileges attaching to membership.
 
@@ -121,14 +121,14 @@ A person qualifies for membership of the co-operative if the person is able to u
 
     a) if the membership ceases in any circumstances specified in section 117 of the Law;
     
-    b) if the member loses their share under these rules or the Law. 
+    b) if the member loses all of their shares under these rules or the Law. 
     
     
 #### 9 Expulsion of members (CNL s117)
 
 1. A member may be expelled from the co-operative by special resolution to the effect:
 
-    a) that the member has seriously or repetitively failed to discharge the memberâ€™s obligations to the co-operative under these rules or a contract entered into with the co-operative under section 125 of the Law; or
+    a) that the member has seriously or repetitively failed to discharge the member’s obligations to the co-operative under these rules or a contract entered into with the co-operative under section 125 of the Law; or
     
     b) that the member has acted in a way that has:
     
@@ -144,7 +144,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
    a)  at the meeting, the member must be afforded a full opportunity to be heard and is entitled to call witnesses and cross-examine witnesses called against the member;
 
-   b) if the member fails to attend at the time and place mentioned, without reasonable excuse, the memberâ€™s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
+   b) if the member fails to attend at the time and place mentioned, without reasonable excuse, the member’s alleged conduct must be considered and the co-operative may decide on the evidence before it, despite the absence of the member;
     
    c) once the alleged conduct is considered, the co-operative may decide to expel the member concerned;
     
@@ -159,7 +159,7 @@ A person qualifies for membership of the co-operative if the person is able to u
 
 #### 10 Resignation of members (CNL s117)
 
-A member may resign from a co-operative by giving two weeksâ€™ notice in writing in the form approved by the board.
+A member may resign from a co-operative by giving two weeks’ notice in writing in the form approved by the board.
 
 
 #### 11 Monetary consequences of expulsion or resignation (CNL s128)
@@ -172,7 +172,7 @@ A member may resign from a co-operative by giving two weeksâ€™ notice in writing
 
 3. The shares of an expelled or resigning member must be cancelled as at the day of expulsion or resignation, and the cancellation must be noted in the register of shares.
 
-4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former memberâ€™s shares at the time of expulsion or resignation (less any amount owing by the former member to the co- operative).
+4. Subject to subrule (5) and the written terms of a class of share issued, the co-operative must, however, pay to the expelled or resigning member the amount of capital paid up on the former member’s shares at the time of expulsion or resignation (less any amount owing by the former member to the co- operative).
 
 5. If a deficiency exists, an appropriate proportion of the loss, deficiency or significant change may be deducted from the amount of capital paid up on the shares of the expelled or resigning member. This is done having regard to the number of shares held by the expelled or resigning member immediately before expulsion or resignation in relation to the number of shares in the co-operative.
 
@@ -258,7 +258,7 @@ A member may resign from a co-operative by giving two weeksâ€™ notice in writing
 >**Note.** Section 130 of the Law applies if mediation does not resolve the dispute.
 
 
-### Division 3 Membersâ€™ liability
+### Division 3 Members’ liability
 
 #### 14 Fines payable by members (CNL ss56 & 126)
 
@@ -280,7 +280,7 @@ A member may resign from a co-operative by giving two weeksâ€™ notice in writing
 
 ### Division 4 Shares
 
-#### 16 Capital and shares (CNL ss76â€“82)
+#### 16 Capital and shares (CNL ss76–82)
 
 1. The capital of the co-operative must be raised by the issue of shares with a nominal value  of $1 each.
 
@@ -302,14 +302,14 @@ No calls on shares will be made.
 >**Note.** 100% of the value of shares must be paid in full at time of application
 
 
-#### 18 Repurchase of membersâ€™ shares (CNL ss99, 107, 109 & 118)
+#### 18 Repurchase of members’ shares (CNL ss99, 107, 109 & 118)
 
-A share may not be repurchased.
+A share may not be repurchased, except when required under these rules or the Law.
 
 
 #### 19 Transfer of shares (CNL ss100 & 101)
 
-A share may not be sold or transferred.
+A share may not be sold or transferred, except when required under these rules or the Law.
 
 
 #### 20 Effect of sale, transfer or disposal of shares (CNL ss232 & 233)  
@@ -320,7 +320,7 @@ A member who for any reason holds less than the minimum number of shares is not 
 
 ### Division 5 Member cancellations
 
-#### 21 Forfeiture and cancellationsâ€”inactive members (CNL ss156â€“163)
+#### 21 Forfeiture and cancellations—inactive members (CNL ss156–163)
 
 1. The board must declare the membership of a member cancelled if:
 
@@ -336,9 +336,9 @@ A member who for any reason holds less than the minimum number of shares is not 
 2. Forfeited shares must be cancelled.
 
 
-#### 23 Forfeited sharesâ€”liability of members
+#### 23 Forfeited shares—liability of members
 
-1. A person whose shares have been forfeited under these rules or the law stops being a member. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by them to the co-operative for the shares.
+1. A person whose shares have been forfeited under these rules or the Law stops being a member. The person nevertheless remains liable to pay to the co-operative all amounts that are (as at the date of forfeiture) payable by them to the co-operative for the shares.
 
 2. A statutory declaration in writing by a director, the chief executive officer or secretary of the co-operative stating that a share in the co-operative has been forfeited and cancelled on a date stated in the declaration, is proof of that fact as against all persons claiming to be entitled to the share.
 
@@ -348,28 +348,29 @@ A member who for any reason holds less than the minimum number of shares is not 
 
 ### Division 6 Deceased or incapacitated members
 
-#### 24 Death of member (CNL ss93 & 102â€“106)
+#### 24 Death of member (CNL ss93 & 102–106)
 
-In the event that a member dies, their shares will be forfeited. 
+The legal personal representative of a deceased member may apply to the board for a transfer of the  
+deceased member’s shares and interest (as defined in Division 8 of the law) in a form approved by the Board. 
 
 #### 25 Rights and liabilities of members under bankruptcy or mental incapacity (CNL ss95, 96 & 117)
 
-1. A personâ€™s membership ceases upon bankruptcy and that personâ€™s shares must be forfeited.
+1. A person’s membership may continue upon bankruptcy for so long as that member continues to meet all regular membership requirements. 
 
-2. A person appointed under a law of a State or Territory to administer the estate of a member who, through mental or physical infirmity, is incapable of managing his or her affairs, may be registered as the holder of the memberâ€™s shares and the rights and liabilities of membership vest in that person during the period of the appointment.
+2. A person appointed under a law of a State or Territory to administer the estate of a member who, through mental or physical infirmity, is incapable of managing his or her affairs, may be registered as the holder of the member’s shares and the rights and liabilities of membership vest in that person during the period of the appointment.
 
 3. The liabilities attaching to the shares of a person under mental incapacity continue in accordance with section 96 of the Law.
 
-4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the memberâ€™s physical or mental infirmity is temporary.
+4. Upon application by a person appointed to manage the affairs of a member referred to in subrule (2), the board may decide to suspend some or all active membership obligations if there are grounds to believe that the member’s physical or mental infirmity is temporary.
 
 
 #### 26 Entitlements and liabilities of person registered as trustee, administrator etc.
 
 1. A person becoming entitled to be a shareholder because of the incapacity of the holder is entitled to the dividends and other advantages to which the person would be entitled if he or she were the registered holder of the share or shares. However, before being registered as a member, the person is not entitled to exercise any right conferred by membership in relation to meetings of the co-operative.
 
-2. A person registered as holder of the shares of a member incapable of managing his or her affairs, has the same liabilities in relation to the share or shares as those to which the deceased, bankrupt or incapable person would have been liable if he or she had remained a member with full legal capacity.
+2. A person registered as holder of the shares of a member incapable of managing his or her affairs, has the same liabilities in relation to the share or shares as those to which the incapable person would have been liable if he or she had remained a member with full legal capacity.
 
-3. The board has the same right to decline or to suspend registration of a share as it would have had for a transfer of a share by the incapacitated person before the bankruptcy or incapacity.
+3. The board has the same right to decline or to suspend registration of a share as it would have had for a transfer of a share by the incapacitated person before the incapacity.
 
 
 
@@ -393,7 +394,7 @@ In the event that a member dies, their shares will be forfeited.
     
 5. Debentures must be transferred in a form approved by the board
 
-#### 28 Issue of CCUs (CNL ss345â€“354)
+#### 28 Issue of CCUs (CNL ss345–354)
 
 The board must not issue CCUs.
 
@@ -409,7 +410,7 @@ The board must not issue CCUs.
 An annual general meeting must be held each year, at a place and on a date and a time decided by the board, within 5 months after the close of the financial year of the co-operative or within the further time allowed by the Registrar.
 
 
-#### 31 Membersâ€™ power to requisition a general meeting (CNL s257)
+#### 31 Members’ power to requisition a general meeting (CNL s257)
 
 1. The board may, whenever it considers appropriate, call a special general meeting of the co-operative.
 
@@ -420,11 +421,11 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 #### 32 Notice of general meetings (CNL ss239, 254 & 611)
 
-1. At least 14 daysâ€™ notice of a general meeting (not including the day on which the notice is served or taken to be served, but including the day for which notice is given) must be given.
+1. At least 14 days’ notice of a general meeting (not including the day on which the notice is served or taken to be served, but including the day for which notice is given) must be given.
 
-> **Note 1.** If there is to be a special resolution proposed at the meeting, there is a requirement for at least 21 daysâ€™ notice of the special resolution.
+> **Note 1.** If there is to be a special resolution proposed at the meeting, there is a requirement for at least 21 days’ notice of the special resolution.
 
-> **Note 2.** If there is a resolution proposed for the removal of a director, section 180 of the Law requires special notice of the resolution and 21 daysâ€™ notice of the meeting.
+> **Note 2.** If there is a resolution proposed for the removal of a director, section 180 of the Law requires special notice of the resolution and 21 days’ notice of the meeting.
 
 2. Notice must be given to each member of the co-operative and any other persons who are, under these rules or the Law, entitled to receive notices from the co-operative.
 
@@ -432,7 +433,7 @@ An annual general meeting must be held each year, at a place and on a date and a
 
 3. The notice must state the place, day and hour of the meeting and include ordinary business as specified in rule 33 and, for special business, the general nature of any special business.
 
-4. The notice must also include any business members have notified their intention to move at the meeting under subrule (6) (but only if the membersâ€™ notification has been made under these rules and within time).
+4. The notice must also include any business members have notified their intention to move at the meeting under subrule (6) (but only if the members’ notification has been made under these rules and within time).
 
 5. The notice must be served in the manner provided in the Law or rule 62.
 
@@ -469,11 +470,11 @@ An annual general meeting must be held each year, at a place and on a date and a
     
     &nbsp;&nbsp; ii) a report on the state of affairs of the co-operative;
     
-    &nbsp;&nbsp; iii) a directorsâ€™ solvency resolution as to whether or not, in their opinion, there are reasonable grounds to believe that the co-operative will be able to pay its debts as and when they become due and payable; and
+    &nbsp;&nbsp; iii) a directors’ solvency resolution as to whether or not, in their opinion, there are reasonable grounds to believe that the co-operative will be able to pay its debts as and when they become due and payable; and
     
     c) to approve any payments of fees to directors.
 
->**Note 1.** A small co-operative must prepare and send to members minimum financial statements that are specified in regulation 3.10 of the National Regulations (these are referred as â€œbasic minimum financial statementsâ€). A co-operative may require more than the basic minimum financial statements to be provided to members and, if so, the additional financial statements should be specified in this rule.
+>**Note 1.** A small co-operative must prepare and send to members minimum financial statements that are specified in regulation 3.10 of the National Regulations (these are referred as “basic minimum financial statements”). A co-operative may require more than the basic minimum financial statements to be provided to members and, if so, the additional financial statements should be specified in this rule.
 
 >**Note 2.** If the small co-operative has consolidated gross assets of less than $250,000 and consolidated revenue of less than $750,000, the financial statement for the small co-operative need not include a cash flow statement (as provided in regulation 3.10 of the National Regulations).
 
@@ -627,7 +628,7 @@ Voting by proxy is not permitted at a general meeting.
 4. If the board decides to conduct a secret postal ballot, it must ensure that the method used to conduct the ballot will ensure that votes can be counted without identifying the way each member has voted.
 
 
-#### 43 Special resolutions (CNL ss238â€“241)
+#### 43 Special resolutions (CNL ss238–241)
 
 1. A special resolution is a resolution that is passed:
 
@@ -670,7 +671,7 @@ Voting by proxy is not permitted at a general meeting.
     
     b) not an active member but who possesses special skills in management or other technical areas of benefit to the co-operative as specified by the board from time to time.
 
-2. A person qualified to be a director under subrule (1)(a) is known as a â€œmember directorâ€. A person qualified under subrule (1)(b) is known as a â€œnon-member directorâ€.
+2. A person qualified to be a director under subrule (1)(a) is known as a “member director”. A person qualified under subrule (1)(b) is known as a “non-member director”.
 
 3. The board of directors must have a majority of member directors.
 
@@ -687,7 +688,7 @@ Voting by proxy is not permitted at a general meeting.
 
 5. The chief executive officer cannot be required to be an active member of the co-operative.
 
-6. In the event of any conflict between the terms of the appointment of a person as the chief executive officer and that personâ€™s obligations or privileges under the Law, the terms of the Law prevail over the terms of appointment.
+6. In the event of any conflict between the terms of the appointment of a person as the chief executive officer and that person’s obligations or privileges under the Law, the terms of the Law prevail over the terms of appointment.
 
 
 #### 47 First directors and election of directors (CNL ss173 & 179)
@@ -698,7 +699,7 @@ Voting by proxy is not permitted at a general meeting.
 
 2. The term of office of the first directors is to be not more than 3 years ending on the day of the third annual general meeting after the formation meeting.
 
->**Note.** The rules may require that directorsâ€™ terms are of different length to enable rotational retirement.
+>**Note.** The rules may require that directors’ terms are of different length to enable rotational retirement.
 
 3. The term of office of directors elected thereafter, is to commence from the annual general meeting at which they are elected and ends on the day of the third annual general meeting thereafter.
 
@@ -731,11 +732,11 @@ Voting by proxy is not permitted at a general meeting.
     
     e) The secretary, or an officer nominated by the board, must give details of each person who has been nominated to members with the notice of the annual general meeting. Details to be provided to members must include:
     
-    &nbsp;&nbsp; i) the nomineeâ€™s name; and
+    &nbsp;&nbsp; i) the nominee’s name; and
     
-    &nbsp;&nbsp; ii) the nomineeâ€™s qualifications and experience; and
+    &nbsp;&nbsp; ii) the nominee’s qualifications and experience; and
     
-    &nbsp;&nbsp; iii) the nomineeâ€™s length of any previous service as a director of the co-operative or with any other co-operative.
+    &nbsp;&nbsp; iii) the nominee’s length of any previous service as a director of the co-operative or with any other co-operative.
 
 6. If the number of nominees equals the number of vacancies, the nominees must be declared elected at the annual general meeting.
 
@@ -758,7 +759,7 @@ Voting by proxy is not permitted at a general meeting.
 
 #### 48 Removal from office of director (CNL s180)
 
-The co-operative may by resolution under section 180 of the Law, with special notice as required by that section, remove a director before the end of the directorâ€™s period of office, and may by a simple majority appoint another person in place of the removed director. The person appointed must retire when the removed director would otherwise have retired.
+The co-operative may by resolution under section 180 of the Law, with special notice as required by that section, remove a director before the end of the director’s period of office, and may by a simple majority appoint another person in place of the removed director. The person appointed must retire when the removed director would otherwise have retired.
 
 
 #### 49 Vacation of office of director (CNL s179)
@@ -774,9 +775,9 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
 3. A person is not qualified to be appointed as an alternate director for:
 
-    a) a member directorâ€”unless the person is qualified for appointment as a member director; or
+    a) a member director—unless the person is qualified for appointment as a member director; or
 
-    b) a non-member directorâ€”unless the person is qualified for appointment as a non-member director.
+    b) a non-member director—unless the person is qualified for appointment as a non-member director.
     
 4. An alternate director holds office until the next annual general meeting or until the next general meeting held to elect directors to fill any vacancies (whichever is earlier).
 
@@ -789,7 +790,7 @@ In addition to the circumstances set out in the Law, a director vacates office i
 
 #### 51 Remuneration of directors (CNL s203)
 
-Directorsâ€™ remuneration must comply with the provisions of the Law.
+Directors’ remuneration must comply with the provisions of the Law.
 
 > **Note 1.** Remuneration for directors is strictly controlled under the Law and requires the approval of the co- operative in general meeting. However, it is possible for a co-operative to specify in its rules that a director will receive particular remuneration if this is appropriate. It may still be necessary to obtain ratification or approval at a general meeting even in respect of specified remuneration under the rules.
 
@@ -845,7 +846,7 @@ Directorsâ€™ remuneration must comply with the provisions of the Law.
 
     e)   a committee of directors and other persons;
 
-    the exercise of the boardâ€™s powers (other than this power of delegation) specified in the resolution. The co- operative or the board may by resolution revoke all or part of the delegation.
+    the exercise of the board’s powers (other than this power of delegation) specified in the resolution. The co- operative or the board may by resolution revoke all or part of the delegation.
 
 2. A power delegated under this rule may, while the delegation remains unrevoked, be exercised from time to time in accordance with the delegation.
 
@@ -889,9 +890,9 @@ Directorsâ€™ remuneration must comply with the provisions of the Law.
 
 ## Part 5 Rules
 
-#### 58 Amendments and copies of rules (CNL ss57 & 60â€“63)
+#### 58 Amendments and copies of rules (CNL ss57 & 60–63)
 
-1. Any amendment of the rules must be approved by special resolution. However, if model rules are adopted in the manner specified under section 65(a) of the Law, any amendments to the model rules as notified by the Registrar are included in the co-operativeâ€™s rules without the need for a special resolution.
+1. Any amendment of the rules must be approved by special resolution. However, if model rules are adopted in the manner specified under section 65(a) of the Law, any amendments to the model rules as notified by the Registrar are included in the co-operative’s rules without the need for a special resolution.
 
 > **Note.** Section 60 of the Law permits the Registrar to specify classes of rules that must not be changed without first obtaining the approval of the Registrar. A co-operative should check whether any prior approval is required before the change is put to a special resolution vote.
 
@@ -909,7 +910,7 @@ Directorsâ€™ remuneration must comply with the provisions of the Law.
 
 1. This rule applies if the co-operative chooses to authenticate a document under the common seal of the co-operative.
 
-2. The co-operativeâ€™s name and registration number must appear on its common seal and any official seal. The common seal must be kept at the registered office in the custody that the board directs.
+2. The co-operative’s name and registration number must appear on its common seal and any official seal. The common seal must be kept at the registered office in the custody that the board directs.
 
 3. The co-operative may have one or more official seals for use outside the State or Territory in place of its common seal. Each of the additional seals must be a facsimile of the common seal with the addition on its face of the name of the place where it is to be used.
 
@@ -985,7 +986,7 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
 2. An auditor or reviewer appointed under this rule holds office until the financial report prepared as a result of the direction has been audited or reviewed and sent to members.
 
 
-#### 67 Disposal of surplus funds during a financial year (CNL ss355â€“358)
+#### 67 Disposal of surplus funds during a financial year (CNL ss355–358)
 
 1. The co-operative may dispose of any surplus arising in a financial year arising from the business of the co-operative in the manner authorised under the Law as determined by the board.
 
@@ -996,7 +997,7 @@ The financial year of the co-operative ends on June 30<sup>th</sup>.
 
 #### 68 Provision for loss
 
-The board must make appropriate provision for losses in the co-operativeâ€™s accounts and when reporting to members is to indicate whether the loss is expected to continue and whether there is any real prejudice to the co-operativeâ€™s solvency.
+The board must make appropriate provision for losses in the co-operative’s accounts and when reporting to members is to indicate whether the loss is expected to continue and whether there is any real prejudice to the co-operative’s solvency.
 
 
 #### 69 Financial reports to members (CNL Part 3.3)
@@ -1013,7 +1014,7 @@ The co-operative must prepare financial reports and statements in accordance wit
     
 1.  The winding up of the co-operative must be in accordance with Part 4.5 of the Law.
     
-2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operativeâ€™s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, which is charitable at law and which has rules prohibiting the distribution of its assets and income to its members.
+2.  If on the winding up or dissolution there remains any property after the satisfaction of all the co-operative’s debts and liabilities (including the refund of the amounts paid up on the shares), this must be transferred to another organisation with similar purposes, which is charitable at law and which has rules prohibiting the distribution of its assets and income to its members.
 
 3.  If on the winding up or dissolution there is a deficiency, members are liable to contribute towards the deficiency to the extent of any amount unpaid on the shares held by the member and any charges payable by the member to the co-operative as required by these rules.
 
@@ -1021,4 +1022,63 @@ The co-operative must prepare financial reports and statements in accordance wit
 #### 71  Non-profit nature of the co-operative 
 
 1.  Notwithstanding any other provision of these rules, the assets and income of the co-operative shall be applied solely to further its purpose as set out in rule 3 (2) and no portion shall be distributed directly or indirectly to the members of the co-operative except as genuine compensation for services rendered or expenses incurred on behalf of the co-operative
-title: Rules of The Electric Boogaloo Co-operative Ltd.
+
+
+
+## Part 9 Policies of the co-operative
+
+#### 72  Effect of policies @(Alternate A)
+
+1. The policies of the co-operative have the effect of a contract under seal—  
+
+    a)  between the co-operative and each member; and 
+
+    b)  between the co-operative and each director, the chief executive officer and  
+the secretary of the co-operative; and 
+
+    c)  between a member and each other member.  
+    
+2.  Under the contract, each of those persons agrees to observe and perform the  
+provisions of the policies as in force for the time being so far as those provisions apply to  
+the person.
+
+
+#### 72  Effect of policies @(Alternate B)
+
+1. The co-operative, as well as each member, director, officer and the secretary of the co-operative, must abide by the policies of the co-operative.
+
+2. The policies of the co-operative may conditionally or unconditionally limit the powers of, or restrict or dictate the decisions which may be made by, the co-operative, as well as each member, director, officer or the secretary of the co-operative.
+
+3. The policies may set out punitive measures if not followed, such as the imposition of fines or the suspension and expulsion of members
+
+
+#### 73  Limitations of policies
+
+1. If a provision of the policies is inconsistent with a provision of the rules, the rules in that instance shall prevail.
+
+2. If a provision of the policies is inconsistent with a provision of the Law, the Law in that instance shall prevail.
+
+3. The cooperative may not approve any policy which, if that policy were a rule amendment, would not be permitted without prior approval of the Registrar under the Law.
+
+>**Note.** Section 60 of the law prohibits certain Rule ammendments without prior approval from the Registrar
+
+
+#### 74  Provisions for the sanction of policies and first policy
+
+1. The first policy (The Policies Policy) of the co-operative must set out:
+   
+   a) the general form of policies;
+   
+   b) how additional policies are to be sanctioned and ammended.
+
+2. The first policy of the co-operative may be sanctioned by an ordinary resolution.
+
+3. Ammendments to the first policy cannot be made by ordinary resolution, unless allowed by a provision of the first policy.
+
+4. Ammendments to the first policy may be made by special resolution.
+
+
+#### 75  Availability of policies
+
+The policies must be made available to all prospective members of the co-operative, and a copy of any policy must be provided to members if requested alongside the rules when provided under rule 58 (3).
+


### PR DESCRIPTION
- Strengthened not-for-profit rule, consolidated relevant rules at the end of the document instead of in membership provisions. 
- Fixed some self-reference errors by re-adding some struck out rules, these will need amending within the restrictions of the law. 
- Improved formatting and fixed a typo present in the original GDocs version of the rules. (Rule 9 I believe)